### PR TITLE
Make sure that we will export directories in PATH

### DIFF
--- a/luna-manager/src/Luna/Manager/Command/Install.hs
+++ b/luna-manager/src/Luna/Manager/Command/Install.hs
@@ -51,20 +51,6 @@ import Data.Aeson (ToJSON, toJSON, toEncoding, encode)
 
 default(Text.Text)
 
--- FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME
--- FIXME: Remove it as fast as we upload config yaml to the server
--- hardcodedRepo :: Repo
--- hardcodedRepo = Repo defpkgs ["studio"] where
---     defpkgs = mempty & at "lib1"         .~ Just (Package "lib1 synopsis"     $ fromList [ (Version 1 0 0 Nothing      , fromList [(SysDesc Linux X64, PackageDesc mempty "path")] )])
---                      & at "luna-studio"  .~ Just (Package "studio synopsis"   $ fromList [ (Version 1 0 0 (Just $ RC 5), fromList [(SysDesc Linux X64, PackageDesc [PackageHeader "lib1" (Version 1 0 0 Nothing)] "path")] )
---                                                                                          , (Version 1 0 0 (Just $ RC 6), fromList [(SysDesc Linux X64, PackageDesc [PackageHeader "lib1" (Version 1 0 0 Nothing)] "path")] )
---                                                                                          , (Version 1 1 0 Nothing      , fromList [(SysDesc Linux X64, PackageDesc [PackageHeader "lib1" (Version 1 0 0 Nothing)] "path")] )
---                                                                                          ])
---
---                      & at "luna"         .~ Just (Package "compiler synopsis" $ fromList [(Version 1 0 0 (Just $ RC 5), fromList [(SysDesc Linux X64, PackageDesc [PackageHeader "lib1" (Version 1 0 0 (Just $ RC 5))] "path")] )])
---                      & at "luna-manager" .~ Just (Package "manager synopsis"  $ fromList [(Version 1 0 0 (Just $ RC 5), fromList [(SysDesc Linux X64, PackageDesc [PackageHeader "lib1" (Version 1 0 0 (Just $ RC 5))] "path")] )])
-
-
 
 ---------------------------------
 -- === Installation config === --
@@ -272,7 +258,7 @@ linkingLocalBin currentBin appName = do
         _       -> do
             localBin <- expand $ (installConfig ^. localBinPath) </> convert appName
             linking currentBin localBin
-            exportPathUnix localBin
+            exportPathUnix =<< expand (installConfig ^. localBinPath)
 
 -- === Windows specific === --
 

--- a/luna-manager/src/Luna/Manager/Command/Install.hs
+++ b/luna-manager/src/Luna/Manager/Command/Install.hs
@@ -256,9 +256,9 @@ linkingLocalBin currentBin appName = do
     case currentHost of
         Windows -> exportPathWindows currentBin
         _       -> do
-            localBin <- expand $ (installConfig ^. localBinPath) </> convert appName
-            linking currentBin localBin
-            exportPathUnix =<< expand (installConfig ^. localBinPath)
+            localBin <- expand (installConfig ^. localBinPath)
+            linking currentBin $ localBin </> convert appName
+            exportPathUnix localBin
 
 -- === Windows specific === --
 

--- a/luna-manager/src/Luna/Manager/System.hs
+++ b/luna-manager/src/Luna/Manager/System.hs
@@ -113,7 +113,7 @@ exportPathUnix pathToExport = do
         Logger.warning $ convert $ encodeString pathToExport <> " is not a directory, exporting " <> encodeString parentDir <> " instead"
         return parentDir
     file               <- getShExportFile
-    let pathToExportText = convert $ encodeString properPathToExport
+    let pathToExportText = Shelly.toTextIgnore properPathToExport
         exportToAppend   = Text.concat ["\nexport PATH=", pathToExportText, ":$PATH\n"]
         warn             = Logger.warning "Unable to export Luna path. Please add ~/.local/bin to your PATH"
     case file of

--- a/luna-manager/src/Luna/Manager/System.hs
+++ b/luna-manager/src/Luna/Manager/System.hs
@@ -15,7 +15,7 @@ import           Data.List.Split              (splitOn)
 import           Data.Text.IO                 (appendFile, readFile)
 import qualified Data.Text                    as Text
 import           Filesystem.Path.CurrentOS    (FilePath, (</>), encodeString, toText, parent)
-import           System.Directory             (executable, setPermissions, getPermissions, doesPathExist, getHomeDirectory)
+import           System.Directory             (executable, setPermissions, getPermissions, doesDirectoryExist, doesPathExist, getHomeDirectory)
 import qualified System.Environment           as Environment
 import           System.Exit
 import qualified System.FilePath              as Path
@@ -104,11 +104,16 @@ getShExportFile = do
     checkedFiles <- mapM runControlCheck files
     return $ listToMaybe $ catMaybes checkedFiles
 
---TODO wyextrachowac wspolna logike dla poszczególnych terminali
+--TODO extract common logic for all unix terminals
 exportPathUnix :: (MonadIO m, MonadBaseControl IO m, LoggerMonad m) => FilePath -> m ()
 exportPathUnix pathToExport = do
-    file <- getShExportFile
-    let pathToExportText = convert $ encodeString pathToExport
+    pathIsDirectory    <- liftIO $ doesDirectoryExist $ encodeString pathToExport
+    properPathToExport <- if pathIsDirectory then return pathToExport else do
+        let parentDir = parent pathToExport
+        Logger.warning $ convert $ encodeString pathToExport <> " is not a directory, exporting " <> encodeString parentDir <> " instead"
+        return parentDir
+    file               <- getShExportFile
+    let pathToExportText = convert $ encodeString properPathToExport
         exportToAppend   = Text.concat ["\nexport PATH=", pathToExportText, ":$PATH\n"]
         warn             = Logger.warning "Unable to export Luna path. Please add ~/.local/bin to your PATH"
     case file of


### PR DESCRIPTION
Main change is in Install.hs where we no longer use path with appName in it to export. However, I also added a validation layer to exportPathUnix that checks if path leads to a directory, and if not it will export its parent.