### PR TITLE
Remove unused option info and show proper error on unexpected argument

### DIFF
--- a/luna-manager/src/Luna/Manager/Command.hs
+++ b/luna-manager/src/Luna/Manager/Command.hs
@@ -28,4 +28,5 @@ chooseCommand = do
         MakePackage opt -> evalDefHostConfigs @'[PackageConfig, EnvConfig, RepoConfig]                        $ CreatePackage.run opt
         Develop     opt -> evalDefHostConfigs @'[Develop.DevelopConfig, EnvConfig, PackageConfig, RepoConfig] $ Develop.run       opt
         NextVersion opt -> evalDefHostConfigs @'[EnvConfig, RepoConfig]                                       $ NextVersion.run   opt
+        a               -> putStrLn $ "Unimplemented option: " ++ show a
         -- TODO: other commands

--- a/luna-manager/src/Luna/Manager/Command/Options.hs
+++ b/luna-manager/src/Luna/Manager/Command/Options.hs
@@ -32,7 +32,6 @@ data Command = Install       InstallOpts
              | Develop       DevelopOpts
              | MakePackage   MakePackageOpts
              | NextVersion   NextVersionOpts
-             | Info
              deriving (Show)
 
 data InstallOpts = InstallOpts
@@ -97,7 +96,7 @@ evalOptionsParserT m = evalStateT m =<< parseOptions
 
 parseOptions :: MonadIO m => m Options
 parseOptions = liftIO $ customExecParser (prefs showHelpOnEmpty) optsParser where
-    commands           = mconcat [cmdInstall, cmdMkpkg, cmdUpdate, cmdDevelop, cmdSwitchVersion, cmdNextVer, cmdInfo]
+    commands           = mconcat [cmdInstall, cmdMkpkg, cmdUpdate, cmdDevelop, cmdSwitchVersion, cmdNextVer]
     optsParser         = info (helper <*> optsProgram) (fullDesc <> header ("Luna ecosystem manager (" <> Info.version <> ")") <> progDesc Info.synopsis)
 
     -- Commands
@@ -107,7 +106,6 @@ parseOptions = liftIO $ customExecParser (prefs showHelpOnEmpty) optsParser wher
     cmdDevelop         = Opts.command "develop"        . info optsDevelop       $ progDesc "Setup development environment"
     cmdMkpkg           = Opts.command "make-package"   . info optsMkpkg         $ progDesc "Prepare installation package"
     cmdNextVer         = Opts.command "next-version"   . info optsNextVersion   $ progDesc "Get a newer version of a package, by default incrementing the build number (x.y.z.w)"
-    cmdInfo            = Opts.command "info"           . info (pure Info)       $ progDesc "Show environment information"
 
     -- Options
     optsProgram        = Options           <$> optsGlobal <*> hsubparser commands


### PR DESCRIPTION
Fixes non-exhaustive pattern match on `./luna-manager info`