### PR TITLE
Command to re-stamp the package with new version (without rebuilding)

### DIFF
--- a/luna-manager/src/Luna/Manager/Command.hs
+++ b/luna-manager/src/Luna/Manager/Command.hs
@@ -15,6 +15,7 @@ import qualified Luna.Manager.Command.CreatePackage as CreatePackage
 import           Luna.Manager.Command.CreatePackage (PackageConfig)
 import qualified Luna.Manager.Command.Develop       as Develop
 import qualified Luna.Manager.Command.NextVersion   as NextVersion
+import qualified Luna.Manager.Command.Promote       as Promote
 import qualified Luna.Manager.Shell.Shelly          as Shelly
 import           Luna.Manager.Shell.Shelly          (MonadSh, MonadShControl)
 import Control.Monad.Trans.Resource ( MonadBaseControl)
@@ -28,5 +29,6 @@ chooseCommand = do
         MakePackage opt -> evalDefHostConfigs @'[PackageConfig, EnvConfig, RepoConfig]                        $ CreatePackage.run opt
         Develop     opt -> evalDefHostConfigs @'[Develop.DevelopConfig, EnvConfig, PackageConfig, RepoConfig] $ Develop.run       opt
         NextVersion opt -> evalDefHostConfigs @'[EnvConfig, RepoConfig]                                       $ NextVersion.run   opt
+        Promote     opt -> evalDefHostConfigs @'[EnvConfig, RepoConfig]                                       $ Promote.run       opt
         a               -> putStrLn $ "Unimplemented option: " ++ show a
         -- TODO: other commands

--- a/luna-manager/src/Luna/Manager/Command/CreatePackage.hs
+++ b/luna-manager/src/Luna/Manager/Command/CreatePackage.hs
@@ -358,7 +358,7 @@ createPkg cfgFolderPath s3GuiURL resolvedApplication = do
     mainAppDir <- case currentHost of
         Windows -> return $ (pkgConfig ^. defaultPackagePath) </> convert appName
         _       -> expand $ appPath </> (pkgConfig ^. defaultPackagePath) </> convert appName
-    let binsFolder  = mainAppDir </> (pkgConfig ^. binFolder)    </> (pkgConfig ^. binsPrivate)
+    let binsFolder  = mainAppDir </> (pkgConfig ^. binFolder) </> (pkgConfig ^. binsPrivate)
         libsFolder  = mainAppDir </> (pkgConfig ^. libPath)
 
 
@@ -366,7 +366,7 @@ createPkg cfgFolderPath s3GuiURL resolvedApplication = do
 
     case currentHost of
         Linux -> createAppimage appName appVersion appPath
-        _     -> void . Archive.pack mainAppDir $ appName <> "-" <> showPretty currentHost <> "-" <> (showPretty appVersion)
+        _     -> void . Archive.pack mainAppDir $ appName <> "-" <> showPretty currentHost <> "-" <> showPretty appVersion
 
     unless buildHead $ Shelly.switchVerbosity $ Shelly.chdir appPath $ do
         Shelly.cmd "git" "checkout" currBranch

--- a/luna-manager/src/Luna/Manager/Command/CreatePackage.hs
+++ b/luna-manager/src/Luna/Manager/Command/CreatePackage.hs
@@ -365,9 +365,8 @@ createPkg cfgFolderPath s3GuiURL resolvedApplication = do
     when (currentHost == Darwin) $ Shelly.silently $ linkLibs binsFolder libsFolder
 
     case currentHost of
-        Linux   -> createAppimage appName appVersion appPath
-        Darwin  -> void . createTarGzUnix mainAppDir $ appName <> "-" <> showPretty currentHost <> "-" <> (showPretty appVersion)
-        Windows -> void . zipFileWindows mainAppDir $ appName <> "-" <> showPretty currentHost <> "-" <> (showPretty appVersion)
+        Linux -> createAppimage appName appVersion appPath
+        _     -> void . Archive.pack mainAppDir $ appName <> "-" <> showPretty currentHost <> "-" <> (showPretty appVersion)
 
     unless buildHead $ Shelly.switchVerbosity $ Shelly.chdir appPath $ do
         Shelly.cmd "git" "checkout" currBranch

--- a/luna-manager/src/Luna/Manager/Command/NextVersion.hs
+++ b/luna-manager/src/Luna/Manager/Command/NextVersion.hs
@@ -46,9 +46,9 @@ makeLenses ''PromotionInfo
 instance Show PromotionInfo where
     show (PromotionInfo appName verType oldVer newVer commit) = header <> " " <> newInfo <> " " <> commitInfo
         where commitInfo = convert $ fromMaybe ""  $ ("from commit " <>) <$> commit
-              header     = "[Promotion info -- " <> (convert appName) <>  "] Previous version: " <> (convert $ showPretty oldVer) <> "."
+              header     = "[Promotion info -- " <> convert appName <>  "] Previous version: " <> (convert $ showPretty oldVer) <> "."
               newVerInfo = (": " <>) . convert . showPretty <$> newVer
-              newInfo    = "Creating new " <> (show verType) <> " version" <> (fromMaybe "" newVerInfo) <> "."
+              newInfo    = "Creating new " <> show verType <> " version" <> fromMaybe "" newVerInfo <> "."
 
 getNewVersion :: PromotionInfo -> Either VersionUpgradeException Version
 getNewVersion prInfo = case prInfo ^. newVersion of

--- a/luna-manager/src/Luna/Manager/Command/NextVersion.hs
+++ b/luna-manager/src/Luna/Manager/Command/NextVersion.hs
@@ -35,7 +35,8 @@ instance Exception VersionUpgradeException
 
 data TargetVersionType = Dev | Nightly | Release deriving (Show, Eq)
 
-data PromotionInfo = PromotionInfo { _versionType :: TargetVersionType
+data PromotionInfo = PromotionInfo { _appName     :: Text
+                                   , _versionType :: TargetVersionType
                                    , _oldVersion  :: Version
                                    , _newVersion  :: Maybe Version
                                    , _commit      :: Maybe Text
@@ -43,9 +44,9 @@ data PromotionInfo = PromotionInfo { _versionType :: TargetVersionType
 makeLenses ''PromotionInfo
 
 instance Show PromotionInfo where
-    show (PromotionInfo verType oldVer newVer commit) = header <> " " <> newInfo <> " " <> commitInfo
+    show (PromotionInfo appName verType oldVer newVer commit) = header <> " " <> newInfo <> " " <> commitInfo
         where commitInfo = convert $ fromMaybe ""  $ ("from commit " <>) <$> commit
-              header     = "[Promotion info] Previous version: " <> (convert $ showPretty oldVer) <> "."
+              header     = "[Promotion info -- " <> (convert appName) <>  "] Previous version: " <> (convert $ showPretty oldVer) <> "."
               newVerInfo = (": " <>) . convert . showPretty <$> newVer
               newInfo    = "Creating new " <> (show verType) <> " version" <> (fromMaybe "" newVerInfo) <> "."
 
@@ -70,7 +71,7 @@ latestVersion appName targetVersionType = do
             _     -> def :: Version
 
 nextVersion :: MonadNextVersion m => PromotionInfo -> m (Either VersionUpgradeException PromotionInfo)
-nextVersion prInfo@(PromotionInfo targetVersionType latestVersion _ _) = do
+nextVersion prInfo@(PromotionInfo _ targetVersionType latestVersion _ _) = do
     let next = case targetVersionType of
             Dev     -> Right . Version.nextBuild
             Nightly -> Version.promoteToNightly
@@ -83,12 +84,13 @@ getAppName cfg = case cfg ^? apps . ix 0 of
     Just app -> Right app
     Nothing  -> Left $ VersionUpgradeException "Unable to determine the app to upgrade."
 
-saveVersion :: MonadNextVersion m => Text -> Text -> PromotionInfo -> m ()
-saveVersion cfgFile appName prInfo = do
-    config  <- Repo.parseConfig $ convert cfgFile
+saveVersion :: MonadNextVersion m => FilePath -> PromotionInfo -> m ()
+saveVersion cfgFile prInfo = do
+    config  <- Repo.parseConfig cfgFile
     version <- tryRight' $ getNewVersion prInfo
-    let newConfig = config & packages . ix appName . versions %~ Map.mapKeys (\_ -> version)
-    Repo.saveYamlToFile newConfig $ convert cfgFile
+    let name      = prInfo ^. appName
+        newConfig = config & packages . ix name . versions %~ Map.mapKeys (\_ -> version)
+    Repo.saveYamlToFile newConfig cfgFile
 
 commitVersion :: MonadNextVersion m => FilePath -> PromotionInfo -> m ()
 commitVersion appPath prInfo = do
@@ -111,23 +113,29 @@ tagVersion appPath prInfo = do
         commitVersion appPath prInfo
         Shelly.run_ "git" (["tag", versionTxt] ++ tagSource)
 
-run :: MonadNextVersion m => NextVersionOpts -> m ()
-run opts = do
-    let cfgPath = opts ^. Opts.configFilePath
-        appPath = parent $ convert cfgPath
-        verType = if opts ^. Opts.release then Release else if opts ^. Opts.nightly then Nightly else Dev
-
-    config    <- Repo.parseConfig $ convert cfgPath
-    appName   <- tryRight' $ getAppName config
-    latestVer <- latestVersion appName verType
+createNextVersion :: MonadNextVersion m => FilePath -> TargetVersionType -> Maybe Text -> m PromotionInfo
+createNextVersion cfgPath verType commitM = do
+    let appPath = parent cfgPath
+    config    <- Repo.parseConfig cfgPath
+    name      <- tryRight' $ getAppName config
+    latestVer <- latestVersion name verType
     liftIO $ Text.putStrLn $ "The latest version is: " <> (showPretty latestVer)
-    let promotionInfo = PromotionInfo { _versionType = verType
+    let promotionInfo = PromotionInfo { _appName     = name
+                                      , _versionType = verType
                                       , _oldVersion  = latestVer
                                       , _newVersion  = Nothing
-                                      , _commit      = opts ^. Opts.commit
+                                      , _commit      = commitM
                                       }
 
     newInfo <- nextVersion promotionInfo >>= tryRight'
     liftIO $ print newInfo
-    saveVersion cfgPath appName newInfo
+    saveVersion cfgPath newInfo
     tagVersion  appPath newInfo
+    return newInfo
+
+run :: MonadNextVersion m => NextVersionOpts -> m ()
+run opts = do
+    let cfgPath = convert $ opts ^. Opts.configFilePath :: FilePath
+        verType = if opts ^. Opts.release then Release else if opts ^. Opts.nightly then Nightly else Dev
+
+    void $ createNextVersion cfgPath verType $ opts ^. Opts.commit

--- a/luna-manager/src/Luna/Manager/Command/Options.hs
+++ b/luna-manager/src/Luna/Manager/Command/Options.hs
@@ -32,6 +32,7 @@ data Command = Install       InstallOpts
              | Develop       DevelopOpts
              | MakePackage   MakePackageOpts
              | NextVersion   NextVersionOpts
+             | Promote       PromoteOpts
              deriving (Show)
 
 data InstallOpts = InstallOpts
@@ -67,6 +68,12 @@ data NextVersionOpts = NextVersionOpts
     , _commit         :: Maybe Text
     } deriving (Show)
 
+data PromoteOpts = PromoteOpts
+    { _confPath  :: Text
+    , _pkgPath   :: Text
+    , _toRelease :: Bool
+    } deriving Show
+
 makeLenses ''GlobalOpts
 makeLenses ''Options
 makeLenses ''InstallOpts
@@ -74,6 +81,7 @@ makeLenses ''MakePackageOpts
 makeLenses ''SwitchVersionOpts
 makeLenses ''DevelopOpts
 makeLenses ''NextVersionOpts
+makeLenses ''PromoteOpts
 
 -- small helpers for Options
 verboseOpt, guiInstallerOpt :: MonadGetter Options m => m Bool
@@ -96,7 +104,7 @@ evalOptionsParserT m = evalStateT m =<< parseOptions
 
 parseOptions :: MonadIO m => m Options
 parseOptions = liftIO $ customExecParser (prefs showHelpOnEmpty) optsParser where
-    commands           = mconcat [cmdInstall, cmdMkpkg, cmdUpdate, cmdDevelop, cmdSwitchVersion, cmdNextVer]
+    commands           = mconcat [cmdInstall, cmdMkpkg, cmdUpdate, cmdDevelop, cmdSwitchVersion, cmdNextVer, cmdPromote]
     optsParser         = info (helper <*> optsProgram) (fullDesc <> header ("Luna ecosystem manager (" <> Info.version <> ")") <> progDesc Info.synopsis)
 
     -- Commands
@@ -106,6 +114,7 @@ parseOptions = liftIO $ customExecParser (prefs showHelpOnEmpty) optsParser wher
     cmdDevelop         = Opts.command "develop"        . info optsDevelop       $ progDesc "Setup development environment"
     cmdMkpkg           = Opts.command "make-package"   . info optsMkpkg         $ progDesc "Prepare installation package"
     cmdNextVer         = Opts.command "next-version"   . info optsNextVersion   $ progDesc "Get a newer version of a package, by default incrementing the build number (x.y.z.w)"
+    cmdPromote         = Opts.command "promote"        . info optsPromote       $ progDesc "Create a nightly (or release) package from a lower version without rebuilding (repackaging only)"
 
     -- Options
     optsProgram        = Options           <$> optsGlobal <*> hsubparser commands
@@ -135,3 +144,7 @@ parseOptions = liftIO $ customExecParser (prefs showHelpOnEmpty) optsParser wher
                                            <*> Opts.switch (long "nightly"   <> help "Get a new nightly version number (x.y.z).")
                                            <*> Opts.switch (long "release"   <> help "Get a new release version number (x.y).")
                                            <*> (optional . strOption $ long "commit" <> metavar "COMMIT" <> help "Commit hash to use as the basis for the new version")
+    optsPromote        = Promote           <$> optsPromote'
+    optsPromote'       = PromoteOpts       <$> strArgument (metavar "CONFIG"  <> help "Config (luna-package.yaml) file path, usually found in the Luna Studio repo")
+                                           <*> strArgument (metavar "PACKAGE" <> help "The path of the package to promote.")
+                                           <*> Opts.switch (long "to-release" <> help "Promote from a nightly build to a release one (default is: dev to nightly)")

--- a/luna-manager/src/Luna/Manager/Command/Options.hs
+++ b/luna-manager/src/Luna/Manager/Command/Options.hs
@@ -105,8 +105,7 @@ evalOptionsParserT m = evalStateT m =<< parseOptions
 
 parseOptions :: MonadIO m => m Options
 parseOptions = liftIO $ customExecParser (prefs showHelpOnEmpty) optsParser where
-    commands           = mconcat [cmdInstall, cmdMkpkg, cmdUpdate, cmdDevelop, cmdSwitchVersion, cmdNextVer, cmdPromote]
-    commands           = mconcat [cmdInstall, cmdUninstall, cmdMkpkg, cmdUpdate, cmdDevelop, cmdSwitchVersion, cmdNextVer]
+    commands           = mconcat [cmdInstall, cmdMkpkg, cmdUpdate, cmdDevelop, cmdSwitchVersion, cmdNextVer, cmdPromote, cmdUninstall]
     optsParser         = info (helper <*> optsProgram) (fullDesc <> header ("Luna ecosystem manager (" <> Info.version <> ")") <> progDesc Info.synopsis)
 
     -- Commands

--- a/luna-manager/src/Luna/Manager/Command/Promote.hs
+++ b/luna-manager/src/Luna/Manager/Command/Promote.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE ExtendedDefaultRules  #-}
+{-# LANGUAGE OverloadedStrings     #-}
+module Luna.Manager.Command.Promote where
+
+import Prologue hiding (FilePath)
+
+import           Control.Exception.Safe            as Exception
+import           Control.Monad.State.Layered
+import qualified Data.Text                         as Text
+import           Filesystem.Path.CurrentOS         (FilePath, parent, encodeString, fromText, (</>))
+
+import qualified Luna.Manager.Archive              as Archive
+import           Luna.Manager.Command.NextVersion  (PromotionInfo(..), TargetVersionType(..), VersionUpgradeException(..), createNextVersion, newVersion, appName)
+import           Luna.Manager.Command.Options      (Options, NextVersionOpts, PromoteOpts)
+import qualified Luna.Manager.Command.Options      as Opts
+import qualified Luna.Manager.Logger               as Logger
+import           Luna.Manager.Network              (MonadNetwork, downloadWithProgressBarTo)
+import           Luna.Manager.Component.Pretty     (showPretty)
+import           Luna.Manager.Component.Repository (RepoConfig)
+import           Luna.Manager.Component.Version    (Version)
+import qualified Luna.Manager.Shell.Shelly         as Shelly
+import           Luna.Manager.System               (makeExecutable)
+import           Luna.Manager.System.Env
+import           Luna.Manager.System.Host          (currentHost, System(..))
+
+default (Text.Text)
+
+type MonadPromote m = (MonadGetter Options m, MonadStates '[EnvConfig, RepoConfig] m, MonadNetwork m, Shelly.MonadSh m, Shelly.MonadShControl m, MonadIO m)
+
+
+renameVersion :: MonadPromote m => FilePath -> Version -> m ()
+renameVersion path version = do
+    let prettyVersion =  showPretty version
+        versionFile   =  encodeString $ path </> "config" </> "version.txt"
+
+    Logger.log $ "Writing new version number: " <> prettyVersion
+    liftIO $ writeFile versionFile (convert prettyVersion)
+
+
+promote' :: MonadPromote m => FilePath -> Text -> Version -> m ()
+promote' pkgPath name version = do
+    Logger.log "Unpacking the package"
+    extracted <- Archive.unpack 1.0 "unpacking_progress" pkgPath
+
+    renameVersion extracted version
+
+    Logger.log "Compressing the package"
+    compressed <- Archive.pack extracted (name <> "1")
+
+
+    -- TODO: change the version in the name of the pkg once it lands
+    Logger.log "Renaming the package"
+    Shelly.mv compressed pkgPath `Exception.catchAny` (\(e :: SomeException) ->
+        Logger.warning "Failed to rename the new package.")
+
+    Logger.log "Cleaning up"
+    Shelly.rm_rf extracted `Exception.catchAny` (\(e :: SomeException) ->
+        Logger.warning $ "Failed to clean up after extracting." <> (convert $ displayException e))
+
+
+promoteLinux :: MonadPromote m => FilePath -> Text -> Version -> m ()
+promoteLinux pkgPath name version = do
+    Logger.log "Unpacking AppImage"
+    Shelly.cmd pkgPath "--appimage-extract"
+
+    let appDir = "squashfs-root" :: FilePath
+    renameVersion (appDir </> "usr") version
+
+    Logger.log "Downloading appImageTool"
+    let aitUrl = "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+    appImageTool <- downloadWithProgressBarTo aitUrl "."
+    makeExecutable appImageTool
+
+    -- TODO: change the version in the name once it lands
+    Logger.log "Repacking AppImage"
+    let aiName    = convert $ name <> ".AppImage"  :: FilePath
+        aiNewName = convert $ name <> "1.AppImage" :: FilePath
+    Shelly.cmd appImageTool appDir aiNewName
+
+    Logger.log "Renaming the AppImage"
+    Shelly.mv aiNewName aiName `Exception.catchAny` (\(e :: SomeException) ->
+        Logger.warning "Failed to rename the new AppImage.")
+
+    Logger.log "Cleaning up"
+    Shelly.rm_rf appDir `Exception.catchAny` (\(e :: SomeException) ->
+        Logger.warning $ "Failed to clean up after extracting." <> (convert $ displayException e))
+
+
+promote :: MonadPromote m => FilePath -> PromotionInfo -> m ()
+promote pkgPath prInfo = do
+    let name = prInfo ^. appName
+    case prInfo ^. newVersion of
+        Nothing -> liftIO $ putStrLn "No version to promote"
+        Just v  -> case currentHost of
+            Linux -> promoteLinux pkgPath name v
+            _     -> promote'     pkgPath name v
+
+
+run :: MonadPromote m => PromoteOpts -> m ()
+run opts = do
+    let cfgPath = convert $ opts ^. Opts.confPath :: FilePath
+        pkgPath = convert $ opts ^. Opts.pkgPath  :: FilePath
+        verType = if opts ^. Opts.toRelease then Release else Nightly
+
+    prInfo <- createNextVersion cfgPath verType Nothing
+    promote pkgPath prInfo


### PR DESCRIPTION
In short, it:
* creates the new version (using `next-version`, so when a tag exists its not created again)
* unpacks the package
* changes the version
* packs the package again