### PR TITLE
Versions for Luna Manager

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,0 +1,120 @@
+import argparse
+import github3
+import os
+import platform
+from subprocess import run
+
+production_branch = 'production'
+
+
+def write_version(v, path):
+    """Write a new version to the `package.yaml` file.
+
+    :param v: the version to write
+    :param path: the path to the `package.yaml` file
+    :return: True if the version already exists, false otherwise.
+    """
+    lines = None
+    with open(path, 'r') as f:
+        lines = f.readlines()
+
+    if not lines:
+        raise Exception('Failed to read the package.yaml file.')
+
+    try:
+        assert lines[1].startswith('version')
+        h, old_v, n = lines[1].split('"')
+        if old_v == v:
+            return True
+        lines[1] = '"'.join([h, v, n])
+    except Exception as e:
+        raise Exception('Failed to substitute the version') from e
+
+    with open(path, 'w') as f:
+        f.writelines(lines)
+
+    return False
+
+
+def git(command, *args):
+    """Run a git command using the provided args"""
+    run([command] + args, check=True)
+
+
+def commit(v, path):
+    """Handle the git part of creating the new version
+
+    :param v: the version to write
+    :param path: the path to the `package.yaml` file
+    """
+    git('add', path)
+    commit_msg = 'New version: ' + v
+    git('commit', '-m', commit_msg)
+    git('tag', v)
+    git('push', 'origin', production_branch)
+
+
+def get_name(version):
+    """Get the name for the new manager, based on the OS and the version."""
+    base_name = 'luna-manager'
+    osname = platform.system().lower()
+    return "-".join([base_name, osname, version])
+
+
+def get_release(repo, tag):
+    """If the release already exists on GitHub, fetch and return it. Create
+    a new release otherwise.
+
+    :param repo: a `Repository` object obtained by calling: github3.login.repository
+    :param tag: the tag with the release version to find
+    :return : a `Release` object.
+    """
+    for r in repo.iter_releases():
+        if r.tag_name == tag:
+            return r
+
+    return repository.create_release(tag_name=version, draft=False, prerelease=True)
+
+
+def deploy(version):
+    """Create a GitHub release for the newly built package."""
+    binary_path = os.path.join('executables', 'luna-manager')
+    tkn = os.environ.get('GITHUB_TOKEN')
+    if not tkn:
+        raise Exception('The GITHUB_TOKEN env variable not set.')
+    gh = github3.login(tkn)
+    repo = gh.repository('luna', 'luna-manager')
+    release = get_release(repo, version)
+    name = get_name(version)
+    with open(binary_path, 'rb') as asset:
+        release.upload_asset(name=name, asset=asset, content_type='application_binary')
+
+
+def run(version, dry_run=False):
+    package_yaml_path = os.path.join('luna-manager', 'package.yaml')
+    print('Creating a new version: {}.'.format(version))
+    ver_exists = write_version(version, package_yaml_path)
+
+    if ver_exists:
+        print('Version is already commited.')
+    else:
+        print('Commiting and tagging the new version.')
+        commit(version, package_yaml_path)
+
+    print('Building the application.')
+    run('stack install')
+
+    if not dry_run:
+        print('Deploying the release to GitHub.')
+        deploy(version)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Build and deploy the Luna Manager')
+    parser.add_argument('version', metavar='VERSION',
+                        help='The version to create in the plaintext form.')
+    parser.add_argument('--dry-run', dest=dry_run, action='store_true',
+                        help='Create the new version without deploying anything')
+    args = parser.parse_args()
+
+    run(args.version, args.dry_run)

--- a/luna-manager/package.yaml
+++ b/luna-manager/package.yaml
@@ -1,5 +1,5 @@
 name:               luna-manager
-version:            "0.1"
+version:            "1.1.1"
 author:             New Byte Order <contact@newbyteorder.com>
 maintainer:         New Byte Order <contact@newbyteorder.com>
 
@@ -34,7 +34,7 @@ dependencies:
   - typelevel
   - signal
   - monad-control
-
+  - file-embed
   - lens-utils
   - constraints
   - transformers
@@ -48,7 +48,8 @@ dependencies:
   - aeson-pretty
   - time
   - uuid
-
+  - template-haskell
+  - unordered-containers
 
 default-extensions:
     - AllowAmbiguousTypes

--- a/luna-manager/src/Luna/Manager/Command.hs
+++ b/luna-manager/src/Luna/Manager/Command.hs
@@ -17,6 +17,7 @@ import qualified Luna.Manager.Command.Develop       as Develop
 import qualified Luna.Manager.Command.NextVersion   as NextVersion
 import qualified Luna.Manager.Command.Promote       as Promote
 import qualified Luna.Manager.Command.Uninstall     as Uninstall
+import qualified Luna.Manager.Command.Version       as Version
 import qualified Luna.Manager.Shell.Shelly          as Shelly
 import           Luna.Manager.Shell.Shelly          (MonadSh, MonadShControl)
 import Control.Monad.Trans.Resource ( MonadBaseControl)
@@ -32,5 +33,6 @@ chooseCommand = do
         NextVersion opt -> evalDefHostConfigs @'[EnvConfig, RepoConfig]                                       $ NextVersion.run   opt
         Promote     opt -> evalDefHostConfigs @'[EnvConfig, RepoConfig]                                       $ Promote.run       opt
         Uninstall       -> evalDefHostConfigs @'[InstallConfig, EnvConfig]                                    $ Uninstall.run
+        Version         -> Version.run
         a               -> putStrLn $ "Unimplemented option: " ++ show a
         -- TODO: other commands

--- a/luna-manager/src/Luna/Manager/Command/Options.hs
+++ b/luna-manager/src/Luna/Manager/Command/Options.hs
@@ -34,6 +34,7 @@ data Command = Install       InstallOpts
              | MakePackage   MakePackageOpts
              | NextVersion   NextVersionOpts
              | Promote       PromoteOpts
+             | Version
              deriving (Show)
 
 data InstallOpts = InstallOpts
@@ -105,7 +106,7 @@ evalOptionsParserT m = evalStateT m =<< parseOptions
 
 parseOptions :: MonadIO m => m Options
 parseOptions = liftIO $ customExecParser (prefs showHelpOnEmpty) optsParser where
-    commands           = mconcat [cmdInstall, cmdMkpkg, cmdUpdate, cmdDevelop, cmdSwitchVersion, cmdNextVer, cmdPromote, cmdUninstall]
+    commands           = mconcat [cmdInstall, cmdMkpkg, cmdUpdate, cmdDevelop, cmdSwitchVersion, cmdNextVer, cmdPromote, cmdUninstall, cmdVersion]
     optsParser         = info (helper <*> optsProgram) (fullDesc <> header ("Luna ecosystem manager (" <> Info.version <> ")") <> progDesc Info.synopsis)
 
     -- Commands
@@ -117,6 +118,7 @@ parseOptions = liftIO $ customExecParser (prefs showHelpOnEmpty) optsParser wher
     cmdMkpkg           = Opts.command "make-package"   . info optsMkpkg         $ progDesc "Prepare installation package"
     cmdNextVer         = Opts.command "next-version"   . info optsNextVersion   $ progDesc "Get a newer version of a package, by default incrementing the build number (x.y.z.w)"
     cmdPromote         = Opts.command "promote"        . info optsPromote       $ progDesc "Create a nightly (or release) package from a lower version without rebuilding (repackaging only)"
+    cmdVersion         = Opts.command "version"        . info (pure Version)    $ progDesc "Print the version information"
 
     -- Options
     optsProgram        = Options           <$> optsGlobal <*> hsubparser commands

--- a/luna-manager/src/Luna/Manager/Command/Version.hs
+++ b/luna-manager/src/Luna/Manager/Command/Version.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE ExtendedDefaultRules #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE TemplateHaskell      #-}
+module Luna.Manager.Command.Version where
+
+import           Prologue
+import           Luna.Manager.Component.Version.TH (getVersion)
+
+
+version :: String
+version = $(getVersion)
+
+
+run :: MonadIO m => m ()
+run = liftIO . putStrLn $ "Luna Manager version " <> version

--- a/luna-manager/src/Luna/Manager/Component/Version/TH.hs
+++ b/luna-manager/src/Luna/Manager/Component/Version/TH.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE TemplateHaskell      #-}
+module Luna.Manager.Component.Version.TH (getVersion) where
+
+import Prologue hiding (lift)
+
+import           Data.ByteString     (ByteString)
+import           Data.FileEmbed
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Yaml           as Yaml
+import           Language.Haskell.TH.Syntax
+
+
+getVersionEither :: ByteString -> Either String Text
+getVersionEither bs = decoded >>= getMap >>= getVer >>= getText
+    where decoded   = Yaml.decodeEither bs :: Either String Yaml.Value
+          err msg   = Left $ "Malformed Yaml (" <> msg <> ")"
+          getMap  x = case x of Yaml.Object o              -> Right o; _ -> err "not an Object"
+          getVer  x = case HM.lookup "version" x of Just x -> Right x; _ -> err "no version"
+          getText x = case x of Yaml.String s              -> Right s; _ -> err "version not a String"
+
+
+packageYaml :: ByteString
+packageYaml = $(embedFile "package.yaml")
+
+
+fromRight' :: Either l r -> r
+fromRight' x = x^?!_Right
+
+
+unsafeGetVersion :: ByteString -> String
+unsafeGetVersion = convert . fromRight' . getVersionEither
+
+
+thUnsafeGetVersion :: ByteString -> Q Exp
+thUnsafeGetVersion = lift . unsafeGetVersion
+
+
+-- Utility function used by `Luna.Manager.Command.Version` that bakes in the
+-- version info at compile time.
+getVersion :: Q Exp
+getVersion = thUnsafeGetVersion packageYaml


### PR DESCRIPTION
**Haskell part:** added a command to display the Luna Manager version:
```
luna-manager version
```
It reads the version from `package.yaml` at compile time, so if it compiles, it's 100% safe on the use-site (and really fast, for that matter).

**Python part:** added a script to build and deploy Luna Manager, much like the `deploy/main.py` script that writes the new version into `package.yaml`, commits it and tags (if not present already) and then builds and deploys to GitHub.