### PR TITLE
#193 fix path quoting on Windows for uninstall

### DIFF
--- a/luna-manager/src/Luna/Manager/Shell/Shelly.hs
+++ b/luna-manager/src/Luna/Manager/Shell/Shelly.hs
@@ -51,10 +51,11 @@ rm_rf path = case currentHost of
     Linux -> Sh.rm_rf path
     Darwin -> Sh.rm_rf path
     Windows -> do
-        Prologue.whenM (Sh.test_d path) $ do
-            list <- Sh.ls path
-            mapM_ rm_rf list
-        Prologue.whenM (Sh.test_e path) $ liftIO $ Process.runProcess_ $ Process.shell $ "powershell Remove-Item -Recurse -Force -Path " <> encodeString path
+        Prologue.whenM (Sh.test_d path) $ cmd_on_quoted_path "rmdir /s /q "
+        Prologue.whenM (Sh.test_e path) $ cmd_on_quoted_path "rm "
+        where
+            cmd_on_quoted_path cmd = liftIO $ Process.runProcess_ $ Process.shell $ cmd <> quoted_path
+            quoted_path = "\"" <> encodeString path <> "\""
 
 switchVerbosity :: Logger.LoggerMonad m => m a -> m a
 switchVerbosity act = do

--- a/luna-manager/src/Luna/Manager/Shell/Shelly.hs
+++ b/luna-manager/src/Luna/Manager/Shell/Shelly.hs
@@ -45,17 +45,17 @@ mv src dst = case currentHost of
         Logger.logObject "dst" dst
         Sh.mv src dst
 
+runCommand :: (MonadIO m) => String -> FilePath -> m ()
+runCommand cmd path = liftIO $ Process.runProcess_ $ Process.shell $ cmd <> quoted_path
+    where quotedPath = "\"" <> encodeString path <> "\""
 
 rm_rf :: (Logger.LoggerMonad m, MonadIO m, MonadSh m, MonadCatch m) => FilePath -> m ()
 rm_rf path = case currentHost of
     Linux -> Sh.rm_rf path
     Darwin -> Sh.rm_rf path
     Windows -> do
-        Prologue.whenM (Sh.test_d path) $ cmd_on_quoted_path "rmdir /s /q "
-        Prologue.whenM (Sh.test_e path) $ cmd_on_quoted_path "rm "
-        where
-            cmd_on_quoted_path cmd = liftIO $ Process.runProcess_ $ Process.shell $ cmd <> quoted_path
-            quoted_path = "\"" <> encodeString path <> "\""
+        Prologue.whenM (Sh.test_d path) $ runCommand "rmdir /s /q " path
+        Prologue.whenM (Sh.test_e path) $ runCommand "rm " path
 
 switchVerbosity :: Logger.LoggerMonad m => m a -> m a
 switchVerbosity act = do


### PR DESCRIPTION
this addresses two things:

- `luna-manager uninstall` wasn't quoting paths so uninstall occurred only partially (#196)
- use of recursive directory listing on Windows took way too much time, replaced with instantaneous `rmdir /q /s` command (equivalent of POSIX `rm -rf`)

(my first if modest lines of Haskell since at least 6 years, hope it's ok; tested locally)

_edit_ by way too much time, I mean that I hit Ctrl-C after 5 minutes on a NVMe SSD, where this sort of thing should be near instantaneous