### PR TITLE
Fix the paths in develop, fix option description

### DIFF
--- a/luna-manager/src/Luna/Manager/Command/Options.hs
+++ b/luna-manager/src/Luna/Manager/Command/Options.hs
@@ -136,7 +136,7 @@ parseOptions = liftIO $ customExecParser (prefs showHelpOnEmpty) optsParser wher
     optsSwitchVersion  = SwitchVersion     <$> optsSwitchVersion'
     optsSwitchVersion' = SwitchVersionOpts <$> strArgument (metavar "VERSION" <> help "Target version to switch to")
     optsDevelop        = Develop           <$> optsDevelop'
-    optsDevelop'       = DevelopOpts       <$> (strArgument $ metavar "CONFIG" <> help "Config (luna-package.yaml) file path, usually found in the Luna Studio repo")
+    optsDevelop'       = DevelopOpts       <$> (strArgument $ metavar "APPLICATION" <> help "Name of the application to install. Example: luna-studio")
                                            <*> (optional . strOption $ long "path" <> metavar "PATH" <> help "Path under which the new repository will be created and set up.")
                                            <*> Opts.switch (long "download-dependencies" <> help "Instead of setting up the fresh repo, just download the external dependencies into the existing repo.")
     optsInstall        = Install           <$> optsInstall'


### PR DESCRIPTION
This changes two things:
* the semantics of the `APP_PATH` variable used to communicate between `luna-manager` and the `bootstrap` script: see https://github.com/luna/luna-studio/pull/1179 for a larger description
* the help command on the develop command to reflect the actual meaning of the parameter.

### Important note

This **NEEDS** to land together with https://github.com/luna/luna-studio/pull/1179 (monorepo someday?) Also, we **MUST** release a new manager/installer when releasing the Luna Studio package that will contain this commit.