### PR TITLE
Use 7Zip for packages

### DIFF
--- a/luna-manager/package.yaml
+++ b/luna-manager/package.yaml
@@ -35,6 +35,7 @@ dependencies:
   - optparse-applicative
   - optparse-applicative
   - path
+  - process
   - prologue
   - resourcet
   - safe

--- a/luna-manager/src/Luna/Manager/Archive.hs
+++ b/luna-manager/src/Luna/Manager/Archive.hs
@@ -5,6 +5,7 @@ module Luna.Manager.Archive where
 import           Prologue hiding (FilePath, (<.>))
 
 import           Luna.Manager.Shell.Shelly (MonadSh)
+import           Control.Concurrent        (threadDelay)
 import           Control.Monad.Raise
 import           Control.Monad.State.Layered
 import qualified Control.Exception.Safe as Exception
@@ -193,6 +194,8 @@ unSevenZzipWin :: UnpackContext m => Double -> Text.Text -> FilePath -> m FilePa
 unSevenZzipWin totalProgress progressFieldName zipFile = do
     guiInstaller <- Opts.guiInstallerOpt
     script       <- download7Zip
+
+    liftIO $ threadDelay 30000000 -- sleep for 30s
 
     if guiInstaller
         then do

--- a/luna-manager/src/Luna/Manager/Archive.hs
+++ b/luna-manager/src/Luna/Manager/Archive.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings     #-}
 module Luna.Manager.Archive where
 
-import           Prologue hiding (FilePath)
+import           Prologue hiding (FilePath, (<.>))
 
 import           Luna.Manager.Shell.Shelly (MonadSh)
 import           Control.Monad.Raise
@@ -12,7 +12,7 @@ import           Control.Error.Util (hush)
 import           Data.Aeson (encode)
 import           Data.Either (either)
 import           Data.IORef
-import           Filesystem.Path.CurrentOS (FilePath, (</>), encodeString, toText, fromText, filename, directory, extension, basename, parent, dirname)
+import           Filesystem.Path.CurrentOS (FilePath, (</>), (<.>), encodeString, toText, fromText, filename, directory, extension, basename, parent, dirname)
 import qualified Filesystem.Path.CurrentOS as FP
 import           Luna.Manager.Gui.InstallationProgress
 import qualified Luna.Manager.Logger as Logger
@@ -225,13 +225,15 @@ gzipWindows folder appName = do
         return name
 
 sevenZipWindows :: UnpackContext m => FilePath -> Text -> m FilePath
-sevenZipWindows folder appName = Shelly.chdir (parent folder) $ do
-    script <- download7Zip
-    let zipFileName = appName <> ".7z"
-        filePattern = (Shelly.toTextIgnore folder) <> "\\*"
-    Shelly.switchVerbosity $
-        Shelly.cmd script "a" "-t7z" zipFileName filePattern
-    return $ Shelly.fromText zipFileName
+sevenZipWindows folder appName = do
+    let dir = parent folder
+    Shelly.chdir dir $ do
+        script <- download7Zip
+        let zipFileName = (Shelly.fromText appName) <.> "7z"
+            filePattern = folder </> "*"
+        Shelly.switchVerbosity $
+            Shelly.cmd script "a" "-t7z" zipFileName filePattern
+        return $ dir </> zipFileName
 
 unpackRPM :: UnpackContext m => FilePath -> FilePath -> m ()
 unpackRPM file filepath = liftIO $ do

--- a/luna-manager/src/Luna/Manager/Archive.hs
+++ b/luna-manager/src/Luna/Manager/Archive.hs
@@ -203,10 +203,9 @@ unSevenZzipWin totalProgress progressFieldName zipFile = do
 
     -- liftIO $ threadDelay 30000000 -- sleep for 30s
 
-    liftIO $ callProcess (path2str script) ["x", "-o" <> path2str dir, "-y", path2str zipFile]
+    liftIO $ callProcess (path2str script) ["x", "-o" <> path2str name, "-y", path2str zipFile]
         
-    listed <- Shelly.ls $ dir </> name
-    return $ if length listed == 1 then head listed else dir </> name
+    return name
 
 pack :: UnpackContext m => FilePath -> Text -> m FilePath
 pack = case currentHost of

--- a/luna-manager/src/Luna/Manager/Archive.hs
+++ b/luna-manager/src/Luna/Manager/Archive.hs
@@ -199,12 +199,13 @@ unSevenZzipWin totalProgress progressFieldName zipFile = do
         name     =  dir </> basename zipFile
         path2str :: FilePath -> String
         path2str = convert . Shelly.toTextIgnore
-        -- dirParam = "-w\"" <> (Shelly.toTextIgnore dir) <> "\""
 
-    -- liftIO $ threadDelay 30000000 -- sleep for 30s
+    liftIO $ callProcess (path2str script)
+           [ "x"
+           , "-o" <> path2str name
+           , "-y", path2str zipFile
+           ]
 
-    liftIO $ callProcess (path2str script) ["x", "-o" <> path2str name, "-y", path2str zipFile]
-        
     return name
 
 pack :: UnpackContext m => FilePath -> Text -> m FilePath

--- a/luna-manager/src/Luna/Manager/Archive.hs
+++ b/luna-manager/src/Luna/Manager/Archive.hs
@@ -228,7 +228,7 @@ sevenZipWindows :: UnpackContext m => FilePath -> Text -> m FilePath
 sevenZipWindows folder appName = Shelly.chdir (parent folder) $ do
     script <- download7Zip
     let zipFileName = appName <> ".7z"
-        filePattern = ".\\" <> (Shelly.toTextIgnore folder) <> "\\*"
+        filePattern = (Shelly.toTextIgnore folder) <> "\\*"
     Shelly.switchVerbosity $
         Shelly.cmd script "a" "-t7z" zipFileName filePattern
     return $ Shelly.fromText zipFileName

--- a/luna-manager/src/Luna/Manager/Archive.hs
+++ b/luna-manager/src/Luna/Manager/Archive.hs
@@ -203,7 +203,7 @@ unSevenZzipWin totalProgress progressFieldName zipFile = do
 
     -- liftIO $ threadDelay 30000000 -- sleep for 30s
 
-    liftIO $ callProcess (path2str script) ["x", path2str zipFile]
+    liftIO $ callProcess (path2str script) ["x", "-o" <> path2str dir, "-y", path2str zipFile]
         
     listed <- Shelly.ls $ dir </> name
     return $ if length listed == 1 then head listed else dir </> name

--- a/luna-manager/src/Luna/Manager/Archive.hs
+++ b/luna-manager/src/Luna/Manager/Archive.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings     #-}
 module Luna.Manager.Archive where
 
-import           Prologue hiding (FilePath, (<.>))
+import           Prologue hiding (FilePath)
 
 import           Luna.Manager.Shell.Shelly (MonadSh)
 import           Control.Monad.Raise
@@ -12,7 +12,7 @@ import           Control.Error.Util (hush)
 import           Data.Aeson (encode)
 import           Data.Either (either)
 import           Data.IORef
-import           Filesystem.Path.CurrentOS (FilePath, (<.>), (</>), encodeString, toText, fromText, filename, directory, extension, basename, parent, dirname)
+import           Filesystem.Path.CurrentOS (FilePath, (</>), encodeString, toText, fromText, filename, directory, extension, basename, parent, dirname)
 import qualified Filesystem.Path.CurrentOS as FP
 import           Luna.Manager.Gui.InstallationProgress
 import qualified Luna.Manager.Logger as Logger
@@ -227,8 +227,11 @@ gzipWindows folder appName = do
 sevenZipWindows :: UnpackContext m => FilePath -> Text -> m FilePath
 sevenZipWindows folder appName = Shelly.chdir (parent folder) $ do
     script <- download7Zip
-    Shelly.switchVerbosity $ Shelly.cmd script "a" folder
-    return $ Shelly.fromText appName <.> "7z"
+    let zipFileName = appName <> ".7z"
+        filePattern = ".\\" <> (Shelly.toTextIgnore folder) <> "\\*"
+    Shelly.switchVerbosity $
+        Shelly.cmd script "a" "-t7z" zipFileName filePattern
+    return $ Shelly.fromText zipFileName
 
 unpackRPM :: UnpackContext m => FilePath -> FilePath -> m ()
 unpackRPM file filepath = liftIO $ do

--- a/luna-manager/src/Luna/Manager/Command/CreatePackage.hs
+++ b/luna-manager/src/Luna/Manager/Command/CreatePackage.hs
@@ -389,6 +389,8 @@ createPkg cfgFolderPath s3GuiURL resolvedApplication = do
                   Linux -> createAppimage appName appVersion appPath
                   _     -> Archive.pack mainAppDir $ finalPackageName appName appVersion
 
+    putStrLn $ "Generated package: " <> show package
+
     generateChecksum  @Crypto.SHA256 package
 
     unless buildHead $ Shelly.switchVerbosity $ Shelly.chdir appPath $ do

--- a/luna-manager/src/Luna/Manager/Command/CreatePackage.hs
+++ b/luna-manager/src/Luna/Manager/Command/CreatePackage.hs
@@ -389,7 +389,7 @@ createPkg cfgFolderPath s3GuiURL resolvedApplication = do
                   Linux -> createAppimage appName appVersion appPath
                   _     -> Archive.pack mainAppDir $ finalPackageName appName appVersion
 
-    putStrLn $ "Generated package: " <> show package
+    Logger.log $ "Generated package: " <> (convert $ show package)
 
     generateChecksum  @Crypto.SHA256 package
 

--- a/luna-manager/src/Luna/Manager/Command/Install.hs
+++ b/luna-manager/src/Luna/Manager/Command/Install.hs
@@ -217,8 +217,9 @@ linkingCurrent appType installPath = do
 makeShortcuts :: MonadInstall m => FilePath -> Text -> m ()
 makeShortcuts packageBinPath appName = when (currentHost == Windows) $ do
     Logger.info "Creating Menu Start shortcut."
-    bin         <- liftIO $ System.getSymbolicLinkTarget $ encodeString packageBinPath
-    binAbsPath  <- Shelly.canonicalize $ (parent packageBinPath) </> (decodeString bin)
+    let binName = Shelly.fromText appName <.> "exe"
+        binPath = (parent $ parent packageBinPath) </> "public" </> (Shelly.fromText appName)
+    binAbsPath  <- Shelly.canonicalize $ binPath </> binName
     appData     <- liftIO $ Environment.getEnv "appdata"
     let menuPrograms = (decodeString appData) </> "Microsoft" </> "Windows" </> "Start Menu" </> "Programs" </> convert ((mkSystemPkgName appName) <> ".lnk")
     exitCode <- liftIO $ Process.runProcess $ Process.shell  ("powershell" <> " \"$s=New-Object -ComObject WScript.Shell; $sc=$s.createShortcut(" <> "\'" <> (encodeString menuPrograms) <> "\'" <> ");$sc.TargetPath=" <> "\'" <> (encodeString binAbsPath) <> "\'" <> ";$sc.Save()\"")

--- a/luna-manager/src/Luna/Manager/Command/Install.hs
+++ b/luna-manager/src/Luna/Manager/Command/Install.hs
@@ -20,7 +20,7 @@ import           Luna.Manager.Network
 import           Luna.Manager.Shell.Question
 import qualified Luna.Manager.Shell.Shelly         as Shelly
 import           Luna.Manager.Shell.Shelly         (toTextIgnore, MonadSh, MonadShControl)
-import           Luna.Manager.System               (makeExecutable, exportPath, askToExportPath, checkShell, runServicesWindows, stopServicesWindows, checkChecksum, shaUriError)
+import           Luna.Manager.System               (makeExecutable, exportPath, askToExportPath, checkShell, runServicesWindows, stopServicesWindows, checkChecksum, shaUriError, stripArchiveExtension)
 import           Luna.Manager.System.Env
 import           Luna.Manager.System.Host
 import           Luna.Manager.System.Path
@@ -194,10 +194,7 @@ downloadAndUnpackApp pkgPath installPath appName appType pkgVersion = do
     stopServices installPath appType
     when guiInstaller $ downloadProgress (Progress 0 1)
     Shelly.mkdir_p $ parent installPath
-    pkgPathNoExtension <- tryJust (shaUriError pkgPath) $ case currentHost of
-            Linux -> Text.stripSuffix "AppImage" pkgPath
-            _     -> Text.stripSuffix "tar.gz" pkgPath
-    let pkgShaPath = pkgPathNoExtension <> "sha256"
+    let pkgShaPath = stripArchiveExtension pkgPath <> ".sha256"
     pkg    <- downloadIfUri pkgPath
     pkgSha <- downloadIfUri pkgShaPath
 

--- a/luna-manager/src/Luna/Manager/Component/Repository.hs
+++ b/luna-manager/src/Luna/Manager/Component/Repository.hs
@@ -245,7 +245,10 @@ updateConfig config resolvedApplication =
         appName    = appHeader ^. name
         mainPackagePath = "https://github.com/luna/"
         applicationPartPackagePath = appName <> "/releases/download/" <> showPretty (view version appHeader) <> "/" <> appName <> "-" <> showPretty currentHost <> "-" <> showPretty (view version appHeader)
-        extension = if currentHost == Linux then ".AppImage" else ".tar.gz"
+        extension = case currentHost of
+            Linux   -> ".AppImage"
+            Darwin  -> ".tar.gz"
+            Windows -> ".7z"
         githubReleasePath = mainPackagePath <> applicationPartPackagePath <> extension
         updatedVersionCfg = config & packages . ix appName . versions %~ Map.mapKeys (\_ -> (view version appHeader))
         updatedConfig     = updatedVersionCfg & packages . ix appName . versions . ix (view version appHeader) . ix currentSysDesc . path .~ githubReleasePath

--- a/luna-manager/src/Luna/Manager/System.hs
+++ b/luna-manager/src/Luna/Manager/System.hs
@@ -197,18 +197,18 @@ instance Exception SHAChecksumDoesNotMatchError where
 
 -- === Utils === --
 
-stripExtensions :: FilePath -> Text
-stripExtensions path = fromMaybe textPath stripped
+stripArchiveExtension :: Text -> Text
+stripArchiveExtension path = fromMaybe path stripped
     where
-        textPath = Shelly.toTextIgnore path
         suffixes = [".7z", ".zip", ".tar.gz", ".tar.xz", ".tar.bz"] :: [Text]
-        tryStrip = flip Text.stripSuffix textPath
+        tryStrip = flip Text.stripSuffix path
         stripped = listToMaybe . catMaybes . map tryStrip $ suffixes
 
 generateChecksum :: forall hash m . (Crypto.HashAlgorithm hash, MonadIO m, MonadException SomeException m) => FilePath -> m ()
 generateChecksum file = do
     sha <- Crypto.hashFile @m @hash $ encodeString file
-    let shaFilePath = stripExtensions file <> ".sha256"
+    let fileTextPath = Shelly.toTextIgnore file
+    let shaFilePath  = stripArchiveExtension fileTextPath <> ".sha256"
     liftIO $ writeFile (convert shaFilePath) (show sha)
 
 -- checking just strings because converting to ByteString will prevent user to check it without manager and

--- a/luna-manager/src/Luna/Manager/System/Env.hs
+++ b/luna-manager/src/Luna/Manager/System/Env.hs
@@ -85,7 +85,7 @@ copyDir src dst = do
 instance {-# OVERLAPPABLE #-} MonadIO m => MonadHostConfig EnvConfig sys arch m where
     defaultHostConfig = do
         sysTmp  <- liftIO System.getTemporaryDirectory
-        lunaTmp <- liftIO $ createTempDirectory sysTmp "luna"
+        lunaTmp <- liftIO $ createTempDirectory sysTmp "lu na"
         return $ EnvConfig $ decodeString lunaTmp
 
 instance {-# OVERLAPPABLE #-} MonadIO m => MonadHostConfig EnvConfig 'Windows arch m where


### PR DESCRIPTION
This PR will make Luna Manager start using 7Zip instead of the `tar` script. This works around the `MAX_PATH` limitations (and performs better and more stable, plus the archives are considerably smaller).

It also tries to be backward-compatible with the old packages.