### PR TITLE
Overhaul of Windows unzipping

### DIFF
--- a/luna-manager/package.yaml
+++ b/luna-manager/package.yaml
@@ -35,6 +35,7 @@ dependencies:
   - optparse-applicative
   - path
   - prologue
+  - process
   - resourcet
   - safe
   - safe-exceptions

--- a/luna-manager/src/Luna/Manager/Archive.hs
+++ b/luna-manager/src/Luna/Manager/Archive.hs
@@ -184,9 +184,9 @@ download7Zip = do
         dll2Path   = "http://packages.luna-lang.org/windows/7z/7zxa.dll"
     
     guiInstaller <- Opts.guiInstallerOpt
-    script       <- download scriptPath
-    _            <- download dll1Path
-    _            <- download dll2Path
+    script       <- downloadFromURL scriptPath "Downloading archiving tool"
+    _            <- downloadFromURL dll1Path   "Downloading the DLL-s (1)"
+    _            <- downloadFromURL dll2Path   "Downloading the DLL-s (2)"
 
     return script
 

--- a/luna-manager/src/Luna/Manager/Archive.hs
+++ b/luna-manager/src/Luna/Manager/Archive.hs
@@ -184,9 +184,9 @@ download7Zip = do
         dll2Path   = "http://packages.luna-lang.org/windows/7z/7zxa.dll"
     
     guiInstaller <- Opts.guiInstallerOpt
-    script       <- downloadFromURL scriptPath "Downloading archiving tool"
-    _            <- downloadFromURL dll1Path   "Downloading the DLL-s (1)"
-    _            <- downloadFromURL dll2Path   "Downloading the DLL-s (2)"
+    script       <- download scriptPath
+    _            <- download dll1Path
+    _            <- download dll2Path
 
     return script
 

--- a/luna-manager/src/Luna/Manager/Archive.hs
+++ b/luna-manager/src/Luna/Manager/Archive.hs
@@ -30,7 +30,6 @@ import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Read     as Text
 import qualified Luna.Manager.Shell.Shelly as Shelly
 import qualified System.Process.Typed as Process
-import System.Process (callProcess)
 import           System.Exit
 import           System.IO (hFlush, stdout, hGetContents)
 default (Text.Text)
@@ -194,13 +193,13 @@ download7Zip = do
 unSevenZzipWin :: UnpackContext m => Double -> Text.Text -> FilePath -> m FilePath
 unSevenZzipWin totalProgress progressFieldName zipFile = do
     guiInstaller <- Opts.guiInstallerOpt
-    script       <- pathToStr <$> download7Zip
+    script       <- download7Zip
     let dir      =  directory zipFile
         name     =  dir </> basename zipFile
 
-    liftIO $ callProcess script [ "x", "-o" <> pathToStr name
-                                , "-y", pathToStr zipFile
-                                ]
+    runProcess script [ "x", "-o" <> Shelly.toTextIgnore name
+                      , "-y", Shelly.toTextIgnore zipFile
+                      ]
     return name
 
 pack :: UnpackContext m => FilePath -> Text -> m FilePath

--- a/luna-manager/src/Luna/Manager/Archive.hs
+++ b/luna-manager/src/Luna/Manager/Archive.hs
@@ -4,7 +4,7 @@ module Luna.Manager.Archive where
 
 import           Prologue hiding (FilePath, (<.>))
 
-import           Luna.Manager.Shell.Shelly (MonadSh, runProcess)
+import           Luna.Manager.Shell.Shelly (MonadSh, runProcess, pathToStr)
 import           Control.Concurrent        (threadDelay)
 import           Control.Monad.Raise
 import           Control.Monad.State.Layered
@@ -30,6 +30,7 @@ import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Read     as Text
 import qualified Luna.Manager.Shell.Shelly as Shelly
 import qualified System.Process.Typed as Process
+import System.Process (callProcess)
 import           System.Exit
 import           System.IO (hFlush, stdout, hGetContents)
 default (Text.Text)
@@ -193,13 +194,13 @@ download7Zip = do
 unSevenZzipWin :: UnpackContext m => Double -> Text.Text -> FilePath -> m FilePath
 unSevenZzipWin totalProgress progressFieldName zipFile = do
     guiInstaller <- Opts.guiInstallerOpt
-    script       <- download7Zip
+    script       <- pathToStr <$> download7Zip
     let dir      =  directory zipFile
         name     =  dir </> basename zipFile
 
-    runProcess script [ "x", "-o" <> Shelly.toTextIgnore name
-                      , "-y", Shelly.toTextIgnore zipFile
-                      ]
+    liftIO $ callProcess script [ "x", "-o" <> pathToStr name
+                                , "-y", pathToStr zipFile
+                                ]
     return name
 
 pack :: UnpackContext m => FilePath -> Text -> m FilePath

--- a/luna-manager/src/Luna/Manager/Network.hs
+++ b/luna-manager/src/Luna/Manager/Network.hs
@@ -63,6 +63,7 @@ execExists = liftIO . (fmap isJust) . findExecutable . convert
 downloadToTmp :: (MonadIO m, MonadGetter EnvConfig m, Logger.LoggerMonad m) 
               => URIPath -> m FilePath
 downloadToTmp url = do
+    liftIO $ putStrLn "DOWNLOADING USING CURL"
     tmp <- getTmpPath
     let filePathTxt = fromJust $ takeFileNameFromURL url
         filePath    = fromText filePathTxt


### PR DESCRIPTION
It usies the regular `System.Process` package instead of `System.Process.Typed` which apparently was giving us weird issues related to file locks. As an additional feature, this PR also changes the temporary directory to a correct one on Windows.