### PR TITLE
Update Windows resource info during creating a package

### DIFF
--- a/luna-manager/src/Luna/Manager/Legal.hs
+++ b/luna-manager/src/Luna/Manager/Legal.hs
@@ -3,8 +3,8 @@ module Luna.Manager.Legal where
 import Prologue
 
 companyName, copyright, productName, productDescription
-	:: (IsString a, Semigroup a) => a
+    :: (IsString a, Semigroup a) => a
 companyName        = "New Byte Order Sp. z o. o."
-copyright          = "© 2018 " <> companyName
+copyright          = "Copyright (c) 2018 " <> companyName
 productName        = "Luna Studio"
 productDescription = "Luna Studio"

--- a/luna-manager/src/Luna/Manager/Legal.hs
+++ b/luna-manager/src/Luna/Manager/Legal.hs
@@ -1,0 +1,10 @@
+module Luna.Manager.Legal where
+
+import Prologue
+
+companyName, copyright, productName, productDescription
+	:: (IsString a, Semigroup a) => a
+companyName        = "New Byte Order Sp. z o. o."
+copyright          = "© 2018 " <> companyName
+productName        = "Luna Studio"
+productDescription = "Luna Studio"

--- a/luna-manager/src/Luna/Manager/Legal.hs
+++ b/luna-manager/src/Luna/Manager/Legal.hs
@@ -6,5 +6,6 @@ companyName, copyright, productName, productDescription
     :: (IsString a, Semigroup a) => a
 companyName        = "New Byte Order Sp. z o. o."
 copyright          = "Copyright (c) 2018 " <> companyName
+-- [TODO]: We should try to extract the `productName` and `productDescription` from application name
 productName        = "Luna Studio"
 productDescription = "Luna Studio"


### PR DESCRIPTION
Fills in details of .exe file such as company name, product version, product name, etc.

Requires Resource Hackger installed in a default path, to be fixed by another pull request. 