### PR TITLE
Resign Windows binaries after promoting package

### DIFF
--- a/luna-manager/src/Luna/Manager/Command.hs
+++ b/luna-manager/src/Luna/Manager/Command.hs
@@ -5,7 +5,6 @@ import Prologue
 import           Control.Monad.Raise
 import           Control.Monad.State.Layered
 import           Control.Monad.Trans.Resource       (MonadBaseControl)
-import           Luna.Manager.Command.CreatePackage (PackageConfig)
 import qualified Luna.Manager.Command.CreatePackage as CreatePackage
 import qualified Luna.Manager.Command.Develop       as Develop
 import           Luna.Manager.Command.Install       (InstallConfig)
@@ -16,6 +15,7 @@ import qualified Luna.Manager.Command.Promote       as Promote
 import qualified Luna.Manager.Command.Uninstall     as Uninstall
 import qualified Luna.Manager.Command.Version       as Version
 import           Luna.Manager.Component.Analytics   (MPUserData)
+import           Luna.Manager.Component.PackageConfig (PackageConfig)
 import           Luna.Manager.Component.Repository
 import           Luna.Manager.Shell.Shelly          (MonadSh, MonadShControl)
 import           Luna.Manager.System.Env
@@ -30,7 +30,7 @@ chooseCommand = do
         MakePackage opt -> evalDefHostConfigs @'[PackageConfig, EnvConfig, RepoConfig]                        $ CreatePackage.run opt
         Develop     opt -> evalDefHostConfigs @'[Develop.DevelopConfig, EnvConfig, PackageConfig, RepoConfig] $ Develop.run       opt
         NextVersion opt -> evalDefHostConfigs @'[EnvConfig, RepoConfig]                                       $ NextVersion.run   opt
-        Promote     opt -> evalDefHostConfigs @'[EnvConfig, RepoConfig]                                       $ Promote.run       opt
+        Promote     opt -> evalDefHostConfigs @'[EnvConfig, RepoConfig, PackageConfig]                        $ Promote.run       opt
         Uninstall       -> evalDefHostConfigs @'[InstallConfig, EnvConfig]                                    $ Uninstall.run
         Version         -> Version.run
         a               -> putStrLn $ "Unimplemented option: " ++ show a

--- a/luna-manager/src/Luna/Manager/Command/Develop.hs
+++ b/luna-manager/src/Luna/Manager/Command/Develop.hs
@@ -17,6 +17,7 @@ import qualified System.Directory             as System
 
 import Control.Monad.Trans.Resource       (MonadBaseControl)
 import Luna.Manager.Command.CreatePackage
+import Luna.Manager.Component.PackageConfig
 import Luna.Manager.Component.Repository
 import Luna.Manager.System.Host
 import Luna.Manager.System.Path           (expand)

--- a/luna-manager/src/Luna/Manager/Component/PackageConfig.hs
+++ b/luna-manager/src/Luna/Manager/Component/PackageConfig.hs
@@ -1,0 +1,64 @@
+module Luna.Manager.Component.PackageConfig where
+
+import Prologue hiding (FilePath, (<.>))
+
+import Filesystem.Path.CurrentOS      (FilePath)
+import Luna.Manager.System.Host
+
+----------------------------
+-- === Package config === --
+----------------------------
+
+-- === Definition === --
+
+data PackageConfig = PackageConfig { _defaultPackagePath :: FilePath
+                                   , _buildScriptPath    :: FilePath
+                                   , _thirdPartyPath     :: FilePath
+                                   , _libPath            :: FilePath
+                                   , _componentsToCopy   :: FilePath
+                                   , _configFolder       :: FilePath
+                                   , _binFolder          :: FilePath
+                                   , _binsPrivate        :: FilePath
+                                   , _binsPublic         :: FilePath
+                                   , _mainBin            :: FilePath
+                                   , _utilsFolder        :: FilePath
+                                   , _logoFileName       :: Text
+                                   , _desktopFileName    :: Text
+                                   , _versionFileName    :: FilePath
+                                   , _permitNoTags       :: Bool
+                                   , _buildFromHead      :: Bool
+                                   }
+
+makeLenses ''PackageConfig
+
+
+
+-- === Instances === --
+
+instance Monad m => MonadHostConfig PackageConfig 'Linux arch m where
+    defaultHostConfig = return $ PackageConfig
+        { _defaultPackagePath = "dist-package"
+        , _buildScriptPath    = "build_luna"
+        , _thirdPartyPath     = "third-party"
+        , _libPath            = "lib"
+        , _componentsToCopy   = "dist"
+        , _configFolder       = "config"
+        , _binFolder          = "bin"
+        , _binsPrivate        = "private"
+        , _binsPublic         = "public"
+        , _mainBin            = "main"
+        , _utilsFolder        = "resources"
+        , _logoFileName       = "logo.svg"
+        , _desktopFileName    = "app.desktop"
+        , _versionFileName    = "version.txt"
+        , _permitNoTags       = False
+        , _buildFromHead      = False
+        }
+
+instance Monad m => MonadHostConfig PackageConfig 'Darwin arch m where
+    defaultHostConfig = defaultHostConfigFor @Linux
+
+instance Monad m => MonadHostConfig PackageConfig 'Windows arch m where
+    defaultHostConfig = reconfig <$> defaultHostConfigFor @Linux where
+        reconfig cfg = cfg & defaultPackagePath .~ "C:\\lp"
+                           & buildScriptPath    .~ "scripts_build\\build.py"

--- a/luna-manager/src/Luna/Manager/Component/WindowsResource.hs
+++ b/luna-manager/src/Luna/Manager/Component/WindowsResource.hs
@@ -1,0 +1,145 @@
+module Luna.Manager.Component.WindowsResource where
+
+import Prologue hiding (FilePath, (<.>))
+
+import Control.Monad.State.Layered
+import Filesystem.Path.CurrentOS      (FilePath, decodeString,
+                                       encodeString, filename,
+                                       (</>))
+import Luna.Manager.Command.Options   (Options)
+import Luna.Manager.Component.Pretty
+import Luna.Manager.Component.Version (Version(..), VersionInfo(..))
+import Luna.Manager.Shell.Shelly      (runProcess, runRawSystem)
+import Luna.Manager.System.Env
+import System.Directory               (listDirectory)
+import System.Environment             (getEnv)
+
+import qualified Data.Text                              as Text
+import qualified Data.Text.IO                           as Text
+import qualified Filesystem.Path.CurrentOS              as FP
+import qualified Luna.Manager.Legal                     as Legal
+import qualified Luna.Manager.Shell.Shelly              as Shelly
+
+
+type ResourceContext m =
+    ( MonadGetter Options m
+    , MonadStates '[EnvConfig] m
+    , Shelly.MonadSh m
+    , Shelly.MonadShControl m
+    , MonadCatch m
+    , MonadIO m
+    )
+
+updateExeInfo :: ResourceContext m
+    => Version -> FilePath -> m ()
+updateExeInfo version exePath = do
+    let exeName    = filename exePath
+        resHacker  =
+            "C:\\Program Files (x86)\\Resource Hacker\\ResourceHacker.exe"
+        resPath    = FP.replaceExtension exePath "res"
+        rcPath     = FP.replaceExtension exePath "rc"
+    liftIO $ Text.writeFile (encodeString rcPath) $
+        createExeVersionManifest version (convert $ encodeString exeName)
+    runRawSystem resHacker [ "-open", Shelly.toTextIgnore rcPath
+                           , "-save", Shelly.toTextIgnore resPath
+                           , "-action", "compile"
+                           , "-log", "CONSOLE"
+                           ]
+    runRawSystem resHacker [ "-open", Shelly.toTextIgnore exePath
+                           , "-save", Shelly.toTextIgnore exePath
+                           , "-action", "addoverwrite"
+                           , "-resource", Shelly.toTextIgnore resPath
+                           , "-log", "CONSOLE"
+                           ]
+    Shelly.rm_rf rcPath
+    Shelly.rm_rf resPath
+
+createExeVersionManifest :: Version -> Text -> Text
+createExeVersionManifest version exeName =
+    let fullVersion (Version maj min vi) = Version maj min $ Just $ case vi of
+            Nothing                -> VersionInfo 0 (Just 0)
+            Just (VersionInfo n b) -> VersionInfo n (Just $ fromMaybe 0 b)
+        versionFormat    = showPretty $ fullVersion version
+        winVersionFormat = Text.replace "." "," versionFormat
+    in Text.unlines [
+            "VS_VERSION_INFO VERSIONINFO"
+          , Text.concat ["    FILEVERSION    ", winVersionFormat]
+          , Text.concat ["    PRODUCTVERSION ", winVersionFormat]
+          , "{"
+          , "    BLOCK \"StringFileInfo\""
+          , "    {"
+          , "        BLOCK \"040904b0\""
+          , "        {"
+          , Text.concat [
+              "            VALUE \"CompanyName\",        \""
+            , Legal.companyName
+            , "\""
+            ]
+          , Text.concat [
+              "            VALUE \"FileDescription\",    \""
+            , Legal.productDescription
+            , "\""
+            ]
+          , Text.concat [
+              "            VALUE \"FileVersion\",        \""
+            , versionFormat
+            , "\""
+            ]
+          , Text.concat [
+              "            VALUE \"LegalCopyright\",     \""
+            , Legal.copyright
+            , "\""
+            ]
+          , Text.concat [
+              "            VALUE \"OriginalFilename\",   \""
+            , exeName
+            , "\""
+            ]
+          , Text.concat [
+              "            VALUE \"ProductName\",        \""
+            , Legal.productName
+            , "\""
+            ]
+          , Text.concat [
+              "            VALUE \"ProductVersion\",     \""
+            , versionFormat
+            , "\""
+            ]
+          , "        }"
+          , "    }"
+          , "    BLOCK \"VarFileInfo\""
+          , "    {"
+          , "        VALUE \"Translation\", 0x409, 1200"
+          , "    }"
+          , "}"
+        ]
+
+
+updateWindowsMetadata :: ResourceContext m
+    => Version -> FilePath -> FilePath -> m ()
+updateWindowsMetadata version privateBinFolder mainBin = do
+    updateExeInfo version mainBin
+    binaries <- liftIO . listDirectory $ encodeString privateBinFolder
+    forM_ binaries $ \b -> do
+        let fullPath = privateBinFolder </> decodeString b
+        updateExeInfo version fullPath
+
+
+signWindowsBinary :: ResourceContext m => Text -> m ()
+signWindowsBinary binPath = do
+    let signTool     = "c:\\Program Files (x86)\\Windows Kits\\10\\bin\\x64\\signtool.exe"
+        timestampUrl = "http://timestamp.digicert.com"
+    certPath <- liftIO $ convert <$> getEnv "CERT_PATH"
+    certPass <- liftIO $ convert <$> getEnv "CERT_PASS"
+    runProcess signTool [ "sign", "/v", "/f", certPath, "/p", certPass
+                        , "/t", timestampUrl, binPath
+                        ]
+
+signWindowsBinaries :: ResourceContext m
+                    => FilePath -> FilePath -> m ()
+signWindowsBinaries privateBinFolder mainBin = do
+    signWindowsBinary $ Shelly.toTextIgnore mainBin
+    binaries <- liftIO . listDirectory $ encodeString privateBinFolder
+    forM_ binaries $ \b -> do
+        let fullPath  = privateBinFolder </> decodeString b
+        signWindowsBinary $ Shelly.toTextIgnore fullPath


### PR DESCRIPTION
During promotion, we need to update .exe details for our binaries, as version changed. This invalidates previous signatures, so files are signed once again afterwards.