### PR TITLE
Hanging powershell fix

### DIFF
--- a/luna-manager/src/Luna/Manager/Archive.hs
+++ b/luna-manager/src/Luna/Manager/Archive.hs
@@ -58,10 +58,7 @@ unpack totalProgress progressFieldName file = do
     Logger.info $ "Unpacking archive: " <> plainTextPath file
     ext          <- tryJust (extensionError file) $ extension file
     case currentHost of
-        Windows -> case ext of
-            "zip" -> unzipFileWindows file
-            "gz"  -> untarWin  totalProgress progressFieldName file
-            "7z"  -> unSevenZzipWin totalProgress progressFieldName file
+        Windows -> unSevenZzipWin totalProgress progressFieldName file
         Darwin  -> case ext of
             "gz"  -> unpackTarGzUnix totalProgress progressFieldName file
             "zip" -> unzipUnix file

--- a/luna-manager/src/Luna/Manager/Archive.hs
+++ b/luna-manager/src/Luna/Manager/Archive.hs
@@ -58,7 +58,10 @@ unpack totalProgress progressFieldName file = do
     Logger.info $ "Unpacking archive: " <> plainTextPath file
     ext          <- tryJust (extensionError file) $ extension file
     case currentHost of
-        Windows -> unSevenZzipWin totalProgress progressFieldName file
+        Windows -> case ext of
+            "zip" -> unzipFileWindows file
+            "gz"  -> untarWin  totalProgress progressFieldName file
+            "7z"  -> unSevenZzipWin totalProgress progressFieldName file
         Darwin  -> case ext of
             "gz"  -> unpackTarGzUnix totalProgress progressFieldName file
             "zip" -> unzipUnix file

--- a/luna-manager/src/Luna/Manager/Command/Install.hs
+++ b/luna-manager/src/Luna/Manager/Command/Install.hs
@@ -325,7 +325,7 @@ registerUninstallInfo installPath = when (currentHost == Windows) $ do
         directory      = parent $ parent installPath -- if default, c:\Program Files\
     pkgHasRegister <- Shelly.test_f registerScript
     when pkgHasRegister $ do
-        let registerPowershell = "powershell -executionpolicy bypass -file \"" <> toTextIgnore registerScript <> "\" \"" <> toTextIgnore directory <> "\""
+        let registerPowershell = "powershell -inputformat none -executionpolicy bypass -file \"" <> toTextIgnore registerScript <> "\" \"" <> toTextIgnore directory <> "\""
         Logger.logProcess registerPowershell
 
 moveUninstallScript :: MonadInstall m => FilePath -> m ()
@@ -470,11 +470,8 @@ run opts = do
             Analytics.mpRegisterUser userInfoPath $ fromMaybe "" emailM
             Analytics.mpTrackEvent "LunaInstaller.Started"
             appPkg           <- Logger.tryJustWithLog "Install.run" undefinedPackageError $ Map.lookup appName (repo ^. packages)
-            Logger.logObject "[run] App package" appPkg
             evaluatedVersion <- Logger.tryJustWithLog "Install.run" (toException $ VersionException $ convert $ show appVersion) $ Map.lookup appVersion $ appPkg ^. versions --tryJust missingPackageDescriptionError $ Map.lookup currentSysDesc $ snd $ Map.lookup appVersion $ appPkg ^. versions
-            Logger.logObject "[run] evaluated version" evaluatedVersion
             appDesc          <- Logger.tryJustWithLog "Install.run" (toException $ MissingPackageDescriptionError appVersion) $ Map.lookup currentSysDesc evaluatedVersion
-            Logger.logObject "[run] app description" appDesc
             let (unresolvedLibs, pkgsToInstall) = Repo.resolve repo appDesc
             when (not $ null unresolvedLibs) $ do
                 let e = UnresolvedDepsError unresolvedLibs
@@ -484,7 +481,6 @@ run opts = do
                 appsToInstall   = filter isToInstall pkgsToInstall
                 resolvedApp     = ResolvedPackage (PackageHeader appName appVersion) appDesc (appPkg ^. appType)
                 allApps         = resolvedApp : appsToInstall
-            Logger.logObject "[run] allApps" allApps
 
             mapM_ (installApp opts) $ allApps
             print $ encode $ InstallationProgress 1

--- a/luna-manager/src/Luna/Manager/Command/Install.hs
+++ b/luna-manager/src/Luna/Manager/Command/Install.hs
@@ -223,8 +223,19 @@ makeShortcuts packageBinPath appName = when (currentHost == Windows) $ do
         binPath = parent (parent packageBinPath) </> "public" </> Shelly.fromText appName
     binAbsPath  <- Shelly.canonicalize $ binPath </> binName
     appData     <- liftIO $ Environment.getEnv "appdata"
-    let menuPrograms = (decodeString appData) </> "Microsoft" </> "Windows" </> "Start Menu" </> "Programs" </> convert ((mkSystemPkgName appName) <> ".lnk")
-    exitCode <- liftIO $ Process.runProcess $ Process.shell  ("powershell" <> " \"$s=New-Object -ComObject WScript.Shell; $sc=$s.createShortcut(" <> "\'" <> (encodeString menuPrograms) <> "\'" <> ");$sc.TargetPath=" <> "\'" <> (encodeString binAbsPath) <> "\'" <> ";$sc.Save()\"")
+    let menuPrograms =
+                decodeString appData
+            </> "Microsoft"
+            </> "Windows"
+            </> "Start Menu"
+            </> "Programs"
+            </> convert (mkSystemPkgName appName <> ".lnk")
+    exitCode <- liftIO $ Process.runProcess $ Process.shell $
+        "powershell -inputformat none " <>
+        "\"$s=New-Object -ComObject WScript.Shell; $sc=$s.createShortcut(" <>
+        "\'" <> encodeString menuPrograms <>
+        "\'');$sc.TargetPath=\'" <> encodeString binAbsPath <>
+        "\';$sc.Save()\""
     unless (exitCode == ExitSuccess) $ Logger.warning $ "Menu Start shortcut was not created. Powershell could not be found in the $PATH"
 
 postInstallation :: MonadInstall m => AppType -> FilePath -> Text -> Text -> Text -> m ()
@@ -325,7 +336,10 @@ registerUninstallInfo installPath = when (currentHost == Windows) $ do
         directory      = parent $ parent installPath -- if default, c:\Program Files\
     pkgHasRegister <- Shelly.test_f registerScript
     when pkgHasRegister $ do
-        let registerPowershell = "powershell -inputformat none -executionpolicy bypass -file \"" <> toTextIgnore registerScript <> "\" \"" <> toTextIgnore directory <> "\""
+        let registerPowershell =
+                "powershell -inputformat none -executionpolicy bypass -file \""
+                <> toTextIgnore registerScript
+                <> "\" \"" <> toTextIgnore directory <> "\""
         Logger.logProcess registerPowershell
 
 moveUninstallScript :: MonadInstall m => FilePath -> m ()

--- a/luna-manager/src/Luna/Manager/Logger.hs
+++ b/luna-manager/src/Luna/Manager/Logger.hs
@@ -74,7 +74,8 @@ log msg = do
 logProcess :: LoggerMonad m => Text -> m ()
 logProcess cmd = do
     logToTmpFile $ cmd <> "\n"
-    (exit, out, err) <- Process.readProcess $ Process.shell $ unpack cmd
+    let proc = Process.readProcess . Process.shell
+    (exit, out, err) <- proc $ unpack cmd
     logToTmpFile $ "output: " <> pack (show out) <> "\n"
     logToTmpFile $ "error: "  <> pack (show err) <> "\n"
 


### PR DESCRIPTION
Some users report that installer is hanging, and from logs it seems that spawned powershell never exits. According to the internet, powershell is waiting for stdin and `-inputformat none` option is supposed to fix that