### PR TITLE
Correctly including dataframes, dry run option

### DIFF
--- a/luna-manager/src/Luna/Manager/Command/Develop.hs
+++ b/luna-manager/src/Luna/Manager/Command/Develop.hs
@@ -15,12 +15,12 @@ import           Luna.Manager.System.Env
 import           Prologue                     hiding (FilePath)
 import qualified System.Directory             as System
 
-import Control.Monad.Trans.Resource       (MonadBaseControl)
+import Control.Monad.Trans.Resource         (MonadBaseControl)
 import Luna.Manager.Command.CreatePackage
 import Luna.Manager.Component.PackageConfig
 import Luna.Manager.Component.Repository
 import Luna.Manager.System.Host
-import Luna.Manager.System.Path           (expand)
+import Luna.Manager.System.Path             (expand)
 
 import qualified Data.Text as T
 default (T.Text)
@@ -72,7 +72,7 @@ downloadAndUnpackStack path = do
                 progressFielsdName = ""
             putStrLn "Downloading stack"
             stackArch <- downloadWithProgressBar stackURL
-            stackArch' <- Archive.unpack totalProgress progressFielsdName stackArch
+            stackArch' <- Archive.unpack totalProgress progressFielsdName stackArch Nothing
             Shelly.whenM (Shelly.test_d path) $ Shelly.rm_rf path
             Shelly.mv stackArch' path
 

--- a/luna-manager/src/Luna/Manager/Command/Install.hs
+++ b/luna-manager/src/Luna/Manager/Command/Install.hs
@@ -202,7 +202,7 @@ downloadAndUnpackApp pkgPath installPath appName appType pkgVersion = do
 
     when guiInstaller $ installationProgress 0
     checkChecksum @Crypto.SHA256 pkg pkgSha
-    unpacked <- Archive.unpack (if currentHost==Windows then 0.5 else 0.9) "installation_progress" pkg
+    unpacked <- Archive.unpack (if currentHost==Windows then 0.5 else 0.9) "installation_progress" pkg Nothing
     Logger.info $ "Copying files from " <> toTextIgnore unpacked <> " to " <> toTextIgnore installPath
     case currentHost of
          Linux   -> do

--- a/luna-manager/src/Luna/Manager/Command/Options.hs
+++ b/luna-manager/src/Luna/Manager/Command/Options.hs
@@ -2,9 +2,9 @@ module Luna.Manager.Command.Options where
 
 import Prologue
 
-import Data.Text (Text)
-import Options.Applicative as Opts
 import Control.Monad.State.Layered
+import Data.Text                   (Text)
+import Options.Applicative         as Opts
 
 import qualified Luna.Manager.System.Info as Info
 
@@ -55,6 +55,7 @@ data MakePackageOpts = MakePackageOpts
     , _extPkgUrls    :: [Text]
     , _permitNoTags  :: Bool
     , _buildFromHead :: Bool
+    , _dryRun        :: Bool
     } deriving (Show)
 
 data SwitchVersionOpts = SwitchVersionOpts
@@ -135,6 +136,7 @@ parseOptions = liftIO $ customExecParser (prefs showHelpOnEmpty) optsParser wher
                                            <*> (many . strOption $ long "external-package" <> metavar "PKG_URL" <> help "URL of an additional external package to include (e.g. Dataframes)")
                                            <*> Opts.switch (long "permit-no-tags"  <> help "Do not throw an error if there is no tag for this version. Use with care.")
                                            <*> Opts.switch (long "build-from-head" <> help "Build bypassing the tag-based flow, using HEAD. Use with care.")
+                                           <*> Opts.switch (long "dry-run"         <> help "Make a dry-run package build, not rebuilding Luna Studio or downloading dependencies (useful for development).")
     optsSwitchVersion  = SwitchVersion     <$> optsSwitchVersion'
     optsSwitchVersion' = SwitchVersionOpts <$> strArgument (metavar "VERSION" <> help "Target version to switch to")
     optsDevelop        = Develop           <$> optsDevelop'

--- a/luna-manager/src/Luna/Manager/Command/Promote.hs
+++ b/luna-manager/src/Luna/Manager/Command/Promote.hs
@@ -11,23 +11,24 @@ import qualified Data.Text                   as Text
 import           Filesystem.Path.CurrentOS   (FilePath, encodeString, filename,
                                               parent, (<.>), (</>))
 
-import qualified Luna.Manager.Archive              as Archive
-import           Luna.Manager.Command.NextVersion  (PromotionInfo (..),
-                                                    TargetVersionType (..),
-                                                    appName, createNextVersion,
-                                                    newVersion, oldVersion)
-import           Luna.Manager.Command.Options      (Options, PromoteOpts)
-import qualified Luna.Manager.Command.Options      as Opts
+import qualified Luna.Manager.Archive                   as Archive
+import           Luna.Manager.Command.NextVersion       (PromotionInfo (..),
+                                                         TargetVersionType (..),
+                                                         appName,
+                                                         createNextVersion,
+                                                         newVersion, oldVersion)
+import           Luna.Manager.Command.Options           (Options, PromoteOpts)
+import qualified Luna.Manager.Command.Options           as Opts
 import           Luna.Manager.Component.PackageConfig
-import           Luna.Manager.Component.Pretty     (showPretty)
-import           Luna.Manager.Component.Repository (RepoConfig, ResolvedApplication)
-import qualified Luna.Manager.Component.Repository as Repository
-import           Luna.Manager.Component.Version    (Version)
+import           Luna.Manager.Component.Pretty          (showPretty)
+import           Luna.Manager.Component.Repository      (RepoConfig,
+                                                         ResolvedApplication)
+import qualified Luna.Manager.Component.Repository      as Repository
+import           Luna.Manager.Component.Version         (Version)
 import qualified Luna.Manager.Component.WindowsResource as WindowsResource
-import qualified Luna.Manager.Logger               as Logger
-import           Luna.Manager.Network              (MonadNetwork,
-                                                    downloadWithProgressBarTo)
-import qualified Luna.Manager.Shell.Shelly         as Shelly
+import qualified Luna.Manager.Logger                    as Logger
+import           Luna.Manager.Network                   (MonadNetwork, downloadWithProgressBarTo)
+import qualified Luna.Manager.Shell.Shelly              as Shelly
 
 import Luna.Manager.System      (generateChecksum, makeExecutable)
 import Luna.Manager.System.Env
@@ -90,7 +91,7 @@ renameVersion path repoPath versionOld versionNew resolvedApplication = do
 promote' :: MonadPromote m => FilePath -> FilePath -> Text -> Version -> Version -> ResolvedApplication -> m ()
 promote' pkgPath repoPath name versionOld versionNew res = do
     Logger.log "Unpacking the package"
-    extracted <- Archive.unpack 1.0 "unpacking_progress" pkgPath
+    extracted <- Archive.unpack 1.0 "unpacking_progress" pkgPath Nothing
 
     renameVersion extracted repoPath versionOld versionNew res
 

--- a/luna-manager/src/Luna/Manager/Gui/Initialize.hs
+++ b/luna-manager/src/Luna/Manager/Gui/Initialize.hs
@@ -2,13 +2,14 @@
 
 module Luna.Manager.Gui.Initialize where
 
-import Prologue hiding (FilePath)
-import Luna.Manager.Component.Repository
-import Luna.Manager.Component.Version
-import qualified Luna.Manager.Logger as Logger
-import Control.Monad.Raise
-import Data.Aeson                         (FromJSON, ToJSON, parseJSON, encode)
-import Control.Lens.Aeson
+import           Control.Lens.Aeson
+import           Control.Monad.Raise
+import           Data.Aeson                        (FromJSON, ToJSON, encode,
+                                                    parseJSON)
+import           Luna.Manager.Component.Repository
+import           Luna.Manager.Component.Version
+import qualified Luna.Manager.Logger               as Logger
+import           Prologue                          hiding (FilePath)
 
 -- === Definition === --
 

--- a/luna-manager/src/Luna/Manager/Logger.hs
+++ b/luna-manager/src/Luna/Manager/Logger.hs
@@ -1,23 +1,23 @@
-{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Luna.Manager.Logger where
 
-import           Prologue                     hiding (FilePath, log)
 import           Control.Monad.Raise
 import           Control.Monad.State.Layered
-import           Data.Text                    (Text, pack, unpack)
-import qualified Data.Text.IO                 as Text
-import           Filesystem.Path.CurrentOS    (FilePath, (</>), decodeString)
-import           Shelly.Lifted                (MonadSh, MonadShControl)
-import qualified Shelly.Lifted                as Sh
-import           System.Directory             (getAppUserDataDirectory)
-import           System.IO                    (hFlush, stdout)
+import           Data.Text                   (Text, pack, unpack)
+import qualified Data.Text.IO                as Text
+import           Filesystem.Path.CurrentOS   (FilePath, decodeString, (</>))
+import           Prologue                    hiding (FilePath, log)
+import           Shelly.Lifted               (MonadSh, MonadShControl)
+import qualified Shelly.Lifted               as Sh
+import           System.Directory            (getAppUserDataDirectory)
+import           System.IO                   (hFlush, stdout)
 import qualified System.Process.Typed        as Process
 
-import           Data.Aeson (FromJSON, ToJSON, encode)
+import Data.Aeson (FromJSON, ToJSON, encode)
 
-import           Luna.Manager.Command.Options
-import           Luna.Manager.System.Env      (EnvConfig)
+import Luna.Manager.Command.Options
+import Luna.Manager.System.Env      (EnvConfig)
 
 
 data WarningMessage = WarningMessage { message :: Text

--- a/luna-manager/src/Luna/Manager/System/Env.hs
+++ b/luna-manager/src/Luna/Manager/System/Env.hs
@@ -4,10 +4,10 @@ module Luna.Manager.System.Env where
 
 import Prologue hiding (FilePath, fromText, toText)
 
+import           Control.Monad.State.Layered
+import           Filesystem.Path.CurrentOS
 import           Luna.Manager.System.Host
 import qualified Shelly.Lifted               as Shelly
-import           Filesystem.Path.CurrentOS
-import           Control.Monad.State.Layered
 import qualified System.Directory            as System
 import           System.IO.Error             (isAlreadyExistsError)
 import           System.IO.Temp              (createTempDirectory)

--- a/luna-manager/src/Luna/Manager/System/Path.hs
+++ b/luna-manager/src/Luna/Manager/System/Path.hs
@@ -1,13 +1,13 @@
 module Luna.Manager.System.Path where
 
-import Prologue hiding (FilePath, null, fromText)
+import Prologue hiding (FilePath, fromText, null)
 
+import Luna.Manager.Logger     (LoggerMonad)
 import Luna.Manager.System.Env
-import           Luna.Manager.Logger (LoggerMonad)
 
-import qualified Filesystem.Path as Path
-import Filesystem.Path (FilePath, null)
-import Filesystem.Path.CurrentOS (fromText, encodeString)
+import           Filesystem.Path           (FilePath, null)
+import qualified Filesystem.Path           as Path
+import           Filesystem.Path.CurrentOS (encodeString, fromText)
 
 type URIPath  = Text
 


### PR DESCRIPTION
This should fix the issues with incorrectly unpacking the dataframes package with `tar`. Eventually, the unpacking logic should be rewritten (or at least heavily refactor), because there is a lot of dead code and overall clutter.

The dry-run option doesn't rebuild any haskell code while building the package. Instead, it takes the existing `dist` and simply copies stuff.

As an added value, this also removes some of the warnings about unused imports.

**NOTE:** this needs to wait for https://github.com/luna/luna-studio/pull/1314 