### PR TITLE
Remove all git operations from the manager's make-package command

### DIFF
--- a/luna-manager/src/Luna/Manager/Command/Options.hs
+++ b/luna-manager/src/Luna/Manager/Command/Options.hs
@@ -49,13 +49,11 @@ data InstallOpts = InstallOpts
     } deriving (Show)
 
 data MakePackageOpts = MakePackageOpts
-    { _cfgPath       :: Text
-    , _pkgVersion    :: Text
-    , _guiURL        :: Maybe Text
-    , _extPkgUrls    :: [Text]
-    , _permitNoTags  :: Bool
-    , _buildFromHead :: Bool
-    , _dryRun        :: Bool
+    { _cfgPath    :: Text
+    , _pkgVersion :: Text
+    , _guiURL     :: Maybe Text
+    , _extPkgUrls :: [Text]
+    , _dryRun     :: Bool
     } deriving (Show)
 
 data SwitchVersionOpts = SwitchVersionOpts
@@ -134,8 +132,6 @@ parseOptions = liftIO $ customExecParser (prefs showHelpOnEmpty) optsParser wher
                                            <*> strArgument (metavar "VERSION" <> help "Package version")
                                            <*> (optional . strOption $ long "gui" <> metavar "GUI_URL" <> help "Path to gui package on S3")
                                            <*> (many . strOption $ long "external-package" <> metavar "PKG_URL" <> help "URL of an additional external package to include (e.g. Dataframes)")
-                                           <*> Opts.switch (long "permit-no-tags"  <> help "Do not throw an error if there is no tag for this version. Use with care.")
-                                           <*> Opts.switch (long "build-from-head" <> help "Build bypassing the tag-based flow, using HEAD. Use with care.")
                                            <*> Opts.switch (long "dry-run"         <> help "Make a dry-run package build, not rebuilding Luna Studio or downloading dependencies (useful for development).")
     optsSwitchVersion  = SwitchVersion     <$> optsSwitchVersion'
     optsSwitchVersion' = SwitchVersionOpts <$> strArgument (metavar "VERSION" <> help "Target version to switch to")

--- a/luna-manager/src/Luna/Manager/Component/PackageConfig.hs
+++ b/luna-manager/src/Luna/Manager/Component/PackageConfig.hs
@@ -2,7 +2,7 @@ module Luna.Manager.Component.PackageConfig where
 
 import Prologue hiding (FilePath, (<.>))
 
-import Filesystem.Path.CurrentOS      (FilePath)
+import Filesystem.Path.CurrentOS (FilePath)
 import Luna.Manager.System.Host
 
 ----------------------------
@@ -25,8 +25,6 @@ data PackageConfig = PackageConfig { _defaultPackagePath :: FilePath
                                    , _logoFileName       :: Text
                                    , _desktopFileName    :: Text
                                    , _versionFileName    :: FilePath
-                                   , _permitNoTags       :: Bool
-                                   , _buildFromHead      :: Bool
                                    }
 
 makeLenses ''PackageConfig
@@ -51,8 +49,6 @@ instance Monad m => MonadHostConfig PackageConfig 'Linux arch m where
         , _logoFileName       = "logo.svg"
         , _desktopFileName    = "app.desktop"
         , _versionFileName    = "version.txt"
-        , _permitNoTags       = False
-        , _buildFromHead      = False
         }
 
 instance Monad m => MonadHostConfig PackageConfig 'Darwin arch m where


### PR DESCRIPTION
The vast majority of our build-related problems stemmed from the Manager checking out tags, checking if the versions were the newest, tagging, branching, etc.

This PR fixes these problems once and for all -- the manager is no longer concerned with version control in anyway. It will build the version you tell it to, from the current commit in the luna studio repository. This simplifies the flow and removes major pitfalls.

**Rationale**: the Manager is not the one deploying the packages and as such it shouldn't be concerned whether the version is newest or not (maybe I'd like to rebuild an older version?)

**Benefits**: No more "Version already exists" errors fired for no apparent reason.