### PR TITLE
Remove hardcoded dependencies of bootstrap

### DIFF
--- a/luna-manager/src/Luna/Manager/Command/Develop.hs
+++ b/luna-manager/src/Luna/Manager/Command/Develop.hs
@@ -115,10 +115,6 @@ run opts = do
         Shelly.prependToPath stackFolderPath
         Shelly.setenv "APP_PATH" $ Shelly.toTextIgnore basePath
         let bootstrapPath      = Shelly.toTextIgnore $ appPath </> (developCfg ^. bootstrapFile)
-            bootstrapPackages  = ["base", "exceptions", "shelly", "text", "directory", "system-filepath"]
-            bootstrapStackArgs = ["--resolver", "lts-8.2", "--install-ghc" , "runghc"]
-                                 <> (bootstrapPackages >>= (\p -> ["--package", p]))
-                                 <> [bootstrapPath]
-        Shelly.run "stack" bootstrapStackArgs
+        Shelly.run "stack" [bootstrapPath]
         downloadDeps appName appPath
 

--- a/luna-manager/src/Luna/Manager/Command/Install.hs
+++ b/luna-manager/src/Luna/Manager/Command/Install.hs
@@ -234,7 +234,7 @@ makeShortcuts packageBinPath appName = when (currentHost == Windows) $ do
         "powershell -inputformat none " <>
         "\"$s=New-Object -ComObject WScript.Shell; $sc=$s.createShortcut(" <>
         "\'" <> encodeString menuPrograms <>
-        "\'');$sc.TargetPath=\'" <> encodeString binAbsPath <>
+        "\');$sc.TargetPath=\'" <> encodeString binAbsPath <>
         "\';$sc.Save()\""
     unless (exitCode == ExitSuccess) $ Logger.warning $ "Menu Start shortcut was not created. Powershell could not be found in the $PATH"
 


### PR DESCRIPTION
The luna-manager should not know nor care what project's bootstrap.hs needs. The bootstrap.hs script should describe its dependencies by itself, as described in https://docs.haskellstack.org/en/stable/GUIDE/#script-interpreter