### PR TITLE
Replace ssh repository url with https in develop command

### DIFF
--- a/luna-manager/src/Luna/Manager/Command/Develop.hs
+++ b/luna-manager/src/Luna/Manager/Command/Develop.hs
@@ -78,7 +78,7 @@ downloadAndUnpackStack path = do
 
 getLatestRepo :: MonadDevelop m => Text -> FilePath -> m Text
 getLatestRepo appName appPath = do
-    let repoPath = "git@github.com:luna/" <> appName <> ".git"
+    let repoPath = "https://github.com/luna/" <> appName <> ".git"
     repoExists <- Shelly.test_d appPath
     if repoExists
         then Shelly.chdir appPath $ Shelly.cmd "git" "pull" "origin" "master"

--- a/luna-manager/src/Luna/Manager/Command/Install.hs
+++ b/luna-manager/src/Luna/Manager/Command/Install.hs
@@ -234,7 +234,7 @@ makeShortcuts packageBinPath appName = when (currentHost == Windows) $ do
         "powershell -inputformat none " <>
         "\"$s=New-Object -ComObject WScript.Shell; $sc=$s.createShortcut(" <>
         "\'" <> encodeString menuPrograms <>
-        "\'');$sc.TargetPath=\'" <> encodeString binAbsPath <>
+        "\');$sc.TargetPath=\'" <> encodeString binAbsPath <>
         "\';$sc.Save()\""
     unless (exitCode == ExitSuccess) $ Logger.warning $ "Menu Start shortcut was not created. Powershell could not be found in the $PATH"
 


### PR DESCRIPTION
As discussed with @wdanilo, we shall prefer https links, as they allow cloning repositories without having a github account with ssh access configured.
Our repositories are public and we want to have possibly few requirements for people wanting to build Luna.