### PR TITLE
Fixed runRawSystem  [wip]

### DIFF
--- a/luna-manager/src/Luna/Manager/Command/Install.hs
+++ b/luna-manager/src/Luna/Manager/Command/Install.hs
@@ -234,7 +234,7 @@ makeShortcuts packageBinPath appName = when (currentHost == Windows) $ do
         "powershell -inputformat none " <>
         "\"$s=New-Object -ComObject WScript.Shell; $sc=$s.createShortcut(" <>
         "\'" <> encodeString menuPrograms <>
-        "\'');$sc.TargetPath=\'" <> encodeString binAbsPath <>
+        "\');$sc.TargetPath=\'" <> encodeString binAbsPath <>
         "\';$sc.Save()\""
     unless (exitCode == ExitSuccess) $ Logger.warning $ "Menu Start shortcut was not created. Powershell could not be found in the $PATH"
 

--- a/luna-manager/src/Luna/Manager/Shell/Shelly.hs
+++ b/luna-manager/src/Luna/Manager/Shell/Shelly.hs
@@ -61,7 +61,7 @@ runRawSystem :: (Logger.LoggerMonad m, MonadIO m) => FilePath -> [Text] -> m ()
 runRawSystem path args = do
     let pathStr = encodeString path
         argsStr = map convert args
-    ec <- liftIO $ Process.system $ "\"" <> pathStr <> "\"" <> " " <> unwords argsStr
+    ec <- liftIO $ Process.rawSystem pathStr argsStr
     Logger.log $ convert $ show ec
 
 rm_rf :: (Logger.LoggerMonad m, MonadIO m, MonadSh m, MonadCatch m) => FilePath -> m ()

--- a/luna-manager/src/Luna/Manager/Shell/Shelly.hs
+++ b/luna-manager/src/Luna/Manager/Shell/Shelly.hs
@@ -48,6 +48,10 @@ runCommand cmd path = liftIO $ TypedProcess.runProcess_
                              $ TypedProcess.shell $ cmd <> quotedPath
     where quotedPath = "\"" <> encodeString path <> "\""
 
+runShellCmd :: MonadIO m => Text -> m ()
+runShellCmd cmd = liftIO $ TypedProcess.runProcess_
+                         $ TypedProcess.shell $ convert cmd
+    
 runProcess :: (Logger.LoggerMonad m, MonadIO m) => FilePath -> [Text] -> m ()
 runProcess path args = do
     let pathStr = encodeString path


### PR DESCRIPTION
Instead of trying to pretty print string with all arguments, we should just use the proper API, i.e. `rawSystem` function. Even more when we are called `runRawSystem`.
The current attempt fails to properly handle arguments with spaces. Interestingly, the only usage of this function was with such case. I have no idea how that could have been working to anyone on Windows. (different shell???)